### PR TITLE
Minimal changes to make ALB optional and the web acl exportable

### DIFF
--- a/cfm/waf.yaml
+++ b/cfm/waf.yaml
@@ -4,6 +4,7 @@ Parameters:
   AlbArn:
     Type: String
     Description: "Arn of the Application loadbalancer to associate with WAF"
+    Default: "no"
   NamePrefix:
     Type: String
     Description: "Name Prefix"
@@ -220,6 +221,8 @@ Conditions:
   IsWordPressRuleSetExcludedRules: !Equals [ !Ref WordPressRuleSetExcludedRules, "" ]
   IsAmazonIpReputationListExcludedRules: !Equals [ !Ref AmazonIpReputationListExcludedRules, "" ]
   IsRulesAnonymousIpListExcludedRules: !Equals [ !Ref RulesAnonymousIpListExcludedRules, "" ]
+
+  IsAlbArnProvided: !Not [!Equals [ !Ref AlbArn, "no" ]]
 
 Resources:
   WAFWebACL:
@@ -504,8 +507,20 @@ Resources:
 
   WAFWebACLAssociation:
     Type: AWS::WAFv2::WebACLAssociation
+    Condition: IsAlbArnProvided
     Properties:
       ResourceArn:
         Ref: AlbArn
       WebACLArn:
         Fn::GetAtt: [ WAFWebACL, Arn ]
+
+Outputs:
+  WAFWebName:
+    Description: The name of the WafWebACL created
+    Value: !Select [ 0, !Split ["|", !Ref WAFWebACL ]]
+  WAFWebId:
+    Description: The id of the WafWebACL created
+    Value: !Select [ 1, !Split [ "|", !Ref WAFWebACL ]]
+  WAFWebScope:
+    Description: The scope of the WafWebACL created
+    Value: !Select [ 2, !Split [ "|", !Ref WAFWebACL ]]

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,1 +1,13 @@
+locals {
+  waf_outputs = coalescelist(aws_cloudformation_stack.waf.*.outputs, [{}])[0]
+}
 
+output waf_name {
+  description = "The name of the created WAF"
+  value       = lookup(local.waf_outputs, "WAFWebName", null)
+}
+
+output waf_id {
+  description = "The id of the created WAF"
+  value       = lookup(local.waf_outputs, "WAFWebId", null)
+}


### PR DESCRIPTION
# Description

Please explain the changes you made here and link to any relevant issues.
I found this module on the terraform repository for a wafv2 implementation. I wanted to use it across multiple ALBs, however the implementation provided was whollistic.

Changes offered in this PR:
* Enable the AlbArn to be optional (the default value provided by terraform results in a failure to deploy)
* Exports the relevant id such that it can be read and consumed elsewhere