### PR TITLE
Bugfix/switch id and arn

### DIFF
--- a/cfm/waf.yaml
+++ b/cfm/waf.yaml
@@ -516,11 +516,8 @@ Resources:
 
 Outputs:
   WAFWebName:
-    Description: The name of the WafWebACL created
+    Description: The name of the created WafWebACL
     Value: !Select [ 0, !Split ["|", !Ref WAFWebACL ]]
-  WAFWebId:
-    Description: The id of the WafWebACL created
-    Value: !Select [ 1, !Split [ "|", !Ref WAFWebACL ]]
-  WAFWebScope:
-    Description: The scope of the WafWebACL created
-    Value: !Select [ 2, !Split [ "|", !Ref WAFWebACL ]]
+  WAFWebArn:
+    Description: The ARN of the created WafWebACL
+    Value: !GetAtt [ WAFWebACL, Arn ]

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,11 +3,11 @@ locals {
 }
 
 output waf_name {
-  description = "The name of the created WAF"
+  description = "The name of the created WAF Web ACL"
   value       = lookup(local.waf_outputs, "WAFWebName", null)
 }
 
-output waf_id {
-  description = "The id of the created WAF"
-  value       = lookup(local.waf_outputs, "WAFWebId", null)
+output waf_arn {
+  description = "The arn of the created WAF Web ACL"
+  value       = lookup(local.waf_outputs, "WAFWebArn", null)
 }


### PR DESCRIPTION
# Description

Please explain the changes you made here and link to any relevant issues.
I wanted to make providing an AlbArn optional for the module and confused the interfaces between wafregional and wafv2.

Exporting the ARN will actually help other components associate with the wafv2, I apologise for the mistakes in the previous PR.