### PR TITLE
Enable Optional Description Field For WebACL

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ No modules.
 | <a name="input_scope"></a> [scope](#input\_scope) | Specifies whether this is for an AWS CloudFront distribution or for a regional application. Valid values are CLOUDFRONT or REGIONAL. To work with CloudFront, you must also specify the region us-east-1 (N. Virginia) on the AWS provider. | `string` | `"REGIONAL"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags (key-value pairs) passed to resources. | `map(string)` | `{}` | no |
 | <a name="input_visibility_config"></a> [visibility\_config](#input\_visibility\_config) | Visibility config for WAFv2 web acl. https://www.terraform.io/docs/providers/aws/r/wafv2_web_acl.html#visibility-configuration | `map(string)` | `{}` | no |
+| <a name="input_web_acl_description"></a> [web\_acl\_description](#web\_acl\_description) | A friendly description of the WebACL. https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl#description | `string)` | `""` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ No modules.
 | <a name="input_scope"></a> [scope](#input\_scope) | Specifies whether this is for an AWS CloudFront distribution or for a regional application. Valid values are CLOUDFRONT or REGIONAL. To work with CloudFront, you must also specify the region us-east-1 (N. Virginia) on the AWS provider. | `string` | `"REGIONAL"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags (key-value pairs) passed to resources. | `map(string)` | `{}` | no |
 | <a name="input_visibility_config"></a> [visibility\_config](#input\_visibility\_config) | Visibility config for WAFv2 web acl. https://www.terraform.io/docs/providers/aws/r/wafv2_web_acl.html#visibility-configuration | `map(string)` | `{}` | no |
-| <a name="input_web_acl_description"></a> [web\_acl\_description](#web\_acl\_description) | A friendly description of the WebACL. https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl#description | `string)` | `""` | no |
+| <a name="input_web_acl_description"></a> [web\_acl\_description](#web\_acl\_description) | A friendly description of the WebACL. https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl#description | `string` | `null` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,8 @@ resource "aws_wafv2_web_acl" "main" {
   name  = var.name_prefix
   scope = var.scope
 
+  description = var.web_acl_description
+
   default_action {
     dynamic "allow" {
       for_each = var.allow_default_action ? [1] : []

--- a/variables.tf
+++ b/variables.tf
@@ -84,5 +84,5 @@ variable "logging_filter" {
 variable "web_acl_description" {
   type        = string
   description = "A friendly description of the WebACL"
-  default     = ""
+  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -80,3 +80,9 @@ variable "logging_filter" {
   description = "A configuration block that specifies which web requests are kept in the logs and which are dropped. You can filter on the rule action and on the web request labels that were applied by matching rules during web ACL evaluation."
   default     = {}
 }
+
+variable "web_acl_description" {
+  type        = string
+  description = "A friendly description of the WebACL"
+  default     = ""
+}


### PR DESCRIPTION
# Description

This allows a variable to be used in the module to provide a description for the WebACL as it currently defaults to null.

