### PR TITLE
Add optional description fior WebACL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,58 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
-- Update module versions to support v3 provider
+- Add optional description for WebACL
+- use correct loop var for not_statements ([#30](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/30))
+- Fix failing terratests ([#31](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/31))
+
+
+<a name="3.0.1"></a>
+## [3.0.1] - 2021-06-04
+
+- Update outputs to only output when the WAF is enabled ([#28](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/28))
+
+
+<a name="3.0.0"></a>
+## [3.0.0] - 2021-06-03
+
+- RUpdated github action to refer to main branch instead of master ([#27](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/27))
+- Update example to refer to 3.0.0 of the module ([#26](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/26))
+- Readme update ([#25](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/25))
+- Added Terratests ([#22](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/22))
+- Added missing single_header ([#24](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/24))
+- Added byte match statements ([#21](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/21))
+
+
+<a name="2.0.0"></a>
+## [2.0.0] - 2021-05-04
+
+- Module upgrade with logging filter support ([#20](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/20))
+
+
+<a name="1.6.0"></a>
+## [1.6.0] - 2021-04-19
+
+- Added actions, geo match and IP set  ([#18](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/18))
+- spelling ([#19](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/19))
+- Update README.md
+
+
+<a name="1.5.1"></a>
+## [1.5.1] - 2020-11-09
+
+- Update module to remove 0.14 limit ([#17](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/17))
+
+
+<a name="1.5.0"></a>
+## [1.5.0] - 2020-10-05
+
+- Add support for IP sets and rate limiting ([#15](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/15))
+
+
+<a name="1.4.1"></a>
+## [1.4.1] - 2020-08-05
+
+- v3 aws provider support ([#14](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/14))
 
 
 <a name="1.4.0"></a>
@@ -69,7 +120,14 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
-[Unreleased]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/1.4.0...HEAD
+[Unreleased]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/3.0.1...HEAD
+[3.0.1]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/3.0.0...3.0.1
+[3.0.0]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/2.0.0...3.0.0
+[2.0.0]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/1.6.0...2.0.0
+[1.6.0]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/1.5.1...1.6.0
+[1.5.1]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/1.5.0...1.5.1
+[1.5.0]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/1.4.1...1.5.0
+[1.4.1]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/1.4.0...1.4.1
 [1.4.0]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/1.3.0...1.4.0
 [1.3.0]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/1.2.0...1.3.0
 [1.2.0]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/1.1.0...1.2.0

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If referring directly to the code instead of a pinned version, take note that fr
 ```hcl
 module "waf" {
   source = "umotif-public/waf-webaclv2/aws"
-  version = "~> 3.0.1"
+  version = "~> 3.1.0"
 
   name_prefix = "test-waf-setup"
   alb_arn     = module.alb.arn
@@ -238,7 +238,7 @@ module "waf" {
   }
 
   source = "umotif-public/waf-webaclv2/aws"
-  version = "~> 3.0.1"
+  version = "~> 3.1.0"
 
   name_prefix = "test-waf-setup-cloudfront"
   scope = "CLOUDFRONT"
@@ -281,7 +281,7 @@ Module managed by:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.38.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.42.0 |
 
 ## Modules
 
@@ -305,6 +305,7 @@ No modules.
 | <a name="input_allow_default_action"></a> [allow\_default\_action](#input\_allow\_default\_action) | Set to `true` for WAF to allow requests by default. Set to `false` for WAF to block requests by default. | `bool` | `true` | no |
 | <a name="input_create_alb_association"></a> [create\_alb\_association](#input\_create\_alb\_association) | Whether to create alb association with WAF web acl | `bool` | `true` | no |
 | <a name="input_create_logging_configuration"></a> [create\_logging\_configuration](#input\_create\_logging\_configuration) | Whether to create logging configuration in order start logging from a WAFv2 Web ACL to Amazon Kinesis Data Firehose. | `bool` | `false` | no |
+| <a name="input_description"></a> [description](#input\_description) | A friendly description of the WebACL | `string` | `null` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Whether to create the resources. Set to `false` to prevent the module from creating any resources | `bool` | `true` | no |
 | <a name="input_log_destination_configs"></a> [log\_destination\_configs](#input\_log\_destination\_configs) | The Amazon Kinesis Data Firehose Amazon Resource Name (ARNs) that you want to associate with the web ACL. Currently, only 1 ARN is supported. | `list(string)` | `[]` | no |
 | <a name="input_logging_filter"></a> [logging\_filter](#input\_logging\_filter) | A configuration block that specifies which web requests are kept in the logs and which are dropped. You can filter on the rule action and on the web request labels that were applied by matching rules during web ACL evaluation. | `any` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,8 @@ resource "aws_wafv2_web_acl" "main" {
   name  = var.name_prefix
   scope = var.scope
 
+  description = var.description
+
   default_action {
     dynamic "allow" {
       for_each = var.allow_default_action ? [1] : []

--- a/variables.tf
+++ b/variables.tf
@@ -80,3 +80,9 @@ variable "logging_filter" {
   description = "A configuration block that specifies which web requests are kept in the logs and which are dropped. You can filter on the rule action and on the web request labels that were applied by matching rules during web ACL evaluation."
   default     = {}
 }
+
+variable "description" {
+  type        = string
+  description = "A friendly description of the WebACL"
+  default     = null
+}


### PR DESCRIPTION
# Description

This allows a variable to be used in the module to provide a description for the WebACL as it currently defaults to null.

Originally authored by @TheoNolasco