### PR TITLE
Regex pattern set reference statement support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/umotif-public/terraform-aws-waf-webaclv2?style=social)
-
 # terraform-aws-waf-webaclv2
+
+## Note:
+originally created by [umotif-public](https://registry.terraform.io/modules/umotif-public/waf-webaclv2/aws/latest). We are improving this module by adding more
+functionalities. 
 
 Terraform module to configure WAF Web ACL V2 for Application Load Balancer or Cloudfront distribution.
 
@@ -15,6 +18,7 @@ Supported WAF v2 components:
 - Logical Statements (AND, OR, NOT)
 - Size constraint statements
 - Label Match statements
+- Regex pattern set reference statement
 
 ## Terraform versions
 
@@ -397,3 +401,4 @@ brew install pre-commit terraform-docs tflint
 brew tap git-chglog/git-chglog
 brew install git-chglog
 ```
+

--- a/main.tf
+++ b/main.tf
@@ -134,6 +134,50 @@ resource "aws_wafv2_web_acl" "main" {
                   }
                 }
 
+                # scope down regex_pattern_set_reference_statement
+
+                dynamic "regex_pattern_set_reference_statement" {
+                  for_each = length(lookup(scope_down_statement.value, "regex_pattern_set_reference_statement", {})) == 0 ? [] : [lookup(scope_down_statement.value, "regex_pattern_set_reference_statement", {})] 
+                  content {
+                    arn = lookup(regex_pattern_set_reference_statement.value, "arn")  
+                    dynamic "field_to_match" {
+                      for_each = length(lookup(regex_pattern_set_reference_statement.value, "field_to_match", {})) == 0 ? [] : [lookup(regex_pattern_set_reference_statement.value, "field_to_match", {})]
+                      content {
+                        dynamic "uri_path" {
+                          for_each = length(lookup(field_to_match.value, "uri_path", {})) == 0 ? [] : [lookup(field_to_match.value, "uri_path")]
+                          content {}
+                        }
+                        dynamic "all_query_arguments" {
+                          for_each = length(lookup(field_to_match.value, "all_query_arguments", {})) == 0 ? [] : [lookup(field_to_match.value, "all_query_arguments")]
+                          content {}
+                        }
+                        dynamic "body" {
+                          for_each = length(lookup(field_to_match.value, "body", {})) == 0 ? [] : [lookup(field_to_match.value, "body")]
+                          content {}
+                        }
+                        dynamic "method" {
+                          for_each = length(lookup(field_to_match.value, "method", {})) == 0 ? [] : [lookup(field_to_match.value, "method")]
+                          content {}
+                        }
+                        dynamic "query_string" {
+                          for_each = length(lookup(field_to_match.value, "query_string", {})) == 0 ? [] : [lookup(field_to_match.value, "query_string")]
+                          content {}
+                        }
+                        dynamic "single_header" {
+                          for_each = length(lookup(field_to_match.value, "single_header", {})) == 0 ? [] : [lookup(field_to_match.value, "single_header")]
+                          content {
+                            name = lower(lookup(single_header.value, "name"))
+                          }
+                        }
+                      }
+                    }
+                    text_transformation {
+                      priority = lookup(regex_pattern_set_reference_statement.value, "priority")
+                      type     = lookup(regex_pattern_set_reference_statement.value, "type")
+                    }
+                  }
+                }
+
                 # scope down NOT statements
                 dynamic "not_statement" {
                   for_each = length(lookup(scope_down_statement.value, "not_statement", {})) == 0 ? [] : [lookup(scope_down_statement.value, "not_statement", {})]
@@ -470,6 +514,49 @@ resource "aws_wafv2_web_acl" "main" {
           }
         }
 
+        #regex pattern set reference statement
+
+         dynamic "regex_pattern_set_reference_statement" {
+          for_each = length(lookup(rule.value, "regex_pattern_set_reference_statement", {})) == 0 ? [] : [lookup(rule.value, "regex_pattern_set_reference_statement", {})]
+          content {
+              arn = lookup(regex_pattern_set_reference_statement.value, "arn")  
+            dynamic "field_to_match" {
+              for_each = length(lookup(regex_pattern_set_reference_statement.value, "field_to_match", {})) == 0 ? [] : [lookup(regex_pattern_set_reference_statement.value, "field_to_match", {})]
+              content {
+                dynamic "uri_path" {
+                  for_each = length(lookup(field_to_match.value, "uri_path", {})) == 0 ? [] : [lookup(field_to_match.value, "uri_path")]
+                  content {}
+                }
+                dynamic "all_query_arguments" {
+                  for_each = length(lookup(field_to_match.value, "all_query_arguments", {})) == 0 ? [] : [lookup(field_to_match.value, "all_query_arguments")]
+                  content {}
+                }
+                dynamic "body" {
+                  for_each = length(lookup(field_to_match.value, "body", {})) == 0 ? [] : [lookup(field_to_match.value, "body")]
+                  content {}
+                }
+                dynamic "method" {
+                  for_each = length(lookup(field_to_match.value, "method", {})) == 0 ? [] : [lookup(field_to_match.value, "method")]
+                  content {}
+                }
+                dynamic "query_string" {
+                  for_each = length(lookup(field_to_match.value, "query_string", {})) == 0 ? [] : [lookup(field_to_match.value, "query_string")]
+                  content {}
+                }
+                dynamic "single_header" {
+                  for_each = length(lookup(field_to_match.value, "single_header", {})) == 0 ? [] : [lookup(field_to_match.value, "single_header")]
+                  content {
+                    name = lower(lookup(single_header.value, "name"))
+                  }
+                }
+              }
+            }
+            text_transformation {
+              priority = lookup(regex_pattern_set_reference_statement.value, "priority")
+              type     = lookup(regex_pattern_set_reference_statement.value, "type")
+            }
+          }
+        }
         dynamic "geo_match_statement" {
           for_each = length(lookup(rule.value, "geo_match_statement", {})) == 0 ? [] : [lookup(rule.value, "geo_match_statement", {})]
           content {


### PR DESCRIPTION
# Description

Add Regex pattern set reference statement support.

Example usage:

`
rules  = [{
      name     = "AAWSManagedRulesSQLiRuleSet"
      priority = "10"
      override_action = "none"

      visibility_config = {
        cloudwatch_metrics_enabled = true
        metric_name                = "AWSManagedRulesSQLiRuleSet"
        sampled_requests_enabled   = false
      }

      managed_rule_group_statement = {
        name          = "AWSManagedRulesSQLiRuleSet"
        vendor_name   = "AWS"
        excluded_rule = []

         scope_down_statement = {
          regex_pattern_set_reference_statement = {

            arn = aws_wafv2_regex_pattern_set.sqli_regex_scope_down.arn
            field_to_match = {
              uri_path = "{}"
            }
          type = "NONE" # The text transformation type
          priority  = 0
          } 
        }
      } 
    },`
