### PR TITLE
removed duplicated code

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1343,13 +1343,6 @@ resource "aws_wafv2_web_acl" "main" {
           content {
             statement {
 
-              # Scope down NOT ip_set_statement
-              dynamic "ip_set_reference_statement" {
-                for_each = length(lookup(not_statement.value, "ip_set_reference_statement", {})) == 0 ? [] : [lookup(not_statement.value, "ip_set_reference_statement", {})]
-                content {
-                  arn = lookup(ip_set_reference_statement.value, "arn")
-                }
-              }
               # NOT byte_match_statement
               dynamic "byte_match_statement" {
                 for_each = length(lookup(not_statement.value, "byte_match_statement", {})) == 0 ? [] : [lookup(not_statement.value, "byte_match_statement", {})]


### PR DESCRIPTION
# Description

Im receiving an error to deploy a `not_statement` for `ip_set_reference` because i guess theres a duplicated code. So in my PR i removed the duplicated block, please reviewed if I did it right

YOu can see there is a duplicated block on line 1347 and 1413 of `main.tf`file. After removed the duplicated code my code run perfectly.

Issue reported here: https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/52