### PR TITLE
Add 'version' to managed_rule_group_statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
-- docs(README): add missing = sign after not_statement
+
+
+<a name="3.7.1"></a>
+## [3.7.1] - 2022-05-12
+
+- docs(README): add missing = sign after not_statement ([#51](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/51))
 
 
 <a name="3.7.0"></a>
@@ -169,7 +174,8 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
-[Unreleased]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/3.7.0...HEAD
+[Unreleased]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/3.7.1...HEAD
+[3.7.1]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/3.7.0...3.7.1
 [3.7.0]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/3.6.0-patch-1...3.7.0
 [3.6.0-patch-1]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/3.6.0...3.6.0-patch-1
 [3.6.0]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/3.5.0...3.6.0

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ Module managed by:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
 
 ## Providers

--- a/examples/wafv2-sizeconstraint-rules/main.tf
+++ b/examples/wafv2-sizeconstraint-rules/main.tf
@@ -38,6 +38,7 @@ module "waf" {
       managed_rule_group_statement = {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
+        version     = "Version_2.0"
         excluded_rule = [
           "SizeRestrictions_QUERYSTRING",
           "SizeRestrictions_BODY",

--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,7 @@ resource "aws_wafv2_web_acl" "main" {
           content {
             name        = lookup(managed_rule_group_statement.value, "name")
             vendor_name = lookup(managed_rule_group_statement.value, "vendor_name", "AWS")
+            version     = lookup(managed_rule_group_statement.value, "version", null)
 
             dynamic "excluded_rule" {
               for_each = length(lookup(managed_rule_group_statement.value, "excluded_rule", {})) == 0 ? [] : toset(lookup(managed_rule_group_statement.value, "excluded_rule"))

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 0.13.7"
 
   required_providers {
     aws = ">= 4.0.0"


### PR DESCRIPTION
# Description

Add the ability to version a managed rule group as can be noted from their [documentation](https://docs.aws.amazon.com/waf/latest/developerguide/waf-managed-rule-groups-versioning.html).

