### PR TITLE
Exclude rule deprecated in AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,15 @@ module "waf" {
       managed_rule_group_statement = {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
-        excluded_rule = [
-          "SizeRestrictions_QUERYSTRING",
+        rule_action_override = {
+          action_to_use = {
+            count = {}
+          }
+
+          name = "SizeRestrictions_QUERYSTRING",
           "SizeRestrictions_BODY",
           "GenericRFI_QUERYARGUMENTS"
-        ]
+        }
       }
     },
     {

--- a/main.tf
+++ b/main.tf
@@ -120,14 +120,14 @@ resource "aws_wafv2_web_acl" "main" {
             version     = lookup(managed_rule_group_statement.value, "version", null)
 
             dynamic "rule_action_override" {
-              for_each =  lookup(managed_rule_group_statement.value, "rule_action_override", null) == null ? []:[lookup(managed_rule_group_statement.value, "rule_action_override")]
+              for_each = lookup(managed_rule_group_statement.value, "rule_action_override", null) == null ? [] : [lookup(managed_rule_group_statement.value, "rule_action_override")]
               content {
-                name = lookup(rule_action_override.value,"name")
+                name = lookup(rule_action_override.value, "name")
                 dynamic "action_to_use" {
-                  for_each = [lookup(rule_action_override.value,"action_to_use")]
+                  for_each = [lookup(rule_action_override.value, "action_to_use")]
                   content {
                     dynamic "count" {
-                      for_each = lookup(action_to_use.value,"count", null) == null ? []:[lookup(action_to_use.value,"count")]
+                      for_each = lookup(action_to_use.value, "count", null) == null ? [] : [lookup(action_to_use.value, "count")]
                       content {}
                     }
                   }
@@ -1118,7 +1118,7 @@ resource "aws_wafv2_web_acl" "main" {
                 dynamic "body" {
                   for_each = length(lookup(field_to_match.value, "body", {})) == 0 ? [] : [lookup(field_to_match.value, "body")]
                   content {
-                    oversize_handling = upper(lookup(body.value, "oversize_handling"))
+                    #oversize_handling = upper(lookup(body.value, "oversize_handling"))
                   }
                 }
                 dynamic "method" {

--- a/main.tf
+++ b/main.tf
@@ -119,10 +119,19 @@ resource "aws_wafv2_web_acl" "main" {
             vendor_name = lookup(managed_rule_group_statement.value, "vendor_name", "AWS")
             version     = lookup(managed_rule_group_statement.value, "version", null)
 
-            dynamic "excluded_rule" {
-              for_each = length(lookup(managed_rule_group_statement.value, "excluded_rule", {})) == 0 ? [] : toset(lookup(managed_rule_group_statement.value, "excluded_rule"))
+            dynamic "rule_action_override" {
+              for_each =  lookup(managed_rule_group_statement.value, "rule_action_override", null) == null ? []:[lookup(managed_rule_group_statement.value, "rule_action_override")]
               content {
-                name = excluded_rule.value
+                name = lookup(rule_action_override.value,"name")
+                dynamic "action_to_use" {
+                  for_each = [lookup(rule_action_override.value,"action_to_use")]
+                  content {
+                    dynamic "count" {
+                      for_each = lookup(action_to_use.value,"count", null) == null ? []:[lookup(action_to_use.value,"count")]
+                      content {}
+                    }
+                  }
+                }
               }
             }
 


### PR DESCRIPTION
# Description

Please explain the changes you made here and link to any relevant issues.
Change the code to update the rule for AWS managed rules. Excluded rule is deprecated and ned be updated by rule action override.
Changes made in the main.tf line 109 to 123
Changes made in the usage in readme