### PR TITLE
Deprecate 'excluded_rule' and set minimum provider version to 4.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
+
+
+<a name="4.0.0"></a>
+## [4.0.0] - 2023-01-25
+
+- Update Changelog ([#78](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/78))
 - Exclude rule deprecated in AWS ([#77](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/77))
 - Add output `web_acl_logging_configuration_id` ([#75](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/75))
 - Add dynamic rule_group_reference_statement block to attach custom rule groups ([#70](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/70))
@@ -219,7 +225,8 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
-[Unreleased]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/3.8.1...HEAD
+[Unreleased]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/4.0.0...HEAD
+[4.0.0]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/3.8.1...4.0.0
 [3.8.1]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/3.8.0...3.8.1
 [3.8.0]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/3.7.3...3.8.0
 [3.7.3]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/3.7.2...3.7.3

--- a/README.md
+++ b/README.md
@@ -22,19 +22,18 @@ Supported WAF v2 components:
 
 ## Terraform versions
 
-Terraform 0.13+ Pin module version to `~> v3.0`. Submit pull-requests to `main` branch.
-Terraform 0.12 < 0.13. Pin module version to `~> v1.0`.
+Terraform 0.13+ Pin module version to `~> 4.0`. Submit pull-requests to `main` branch.
 
 ## Usage
 
 Please pin down version of this module to exact version
 
-If referring directly to the code instead of a pinned version, take note that from release 3.0.0 all future changes will only be made to the `main` branch.
+If referring directly to the code instead of a pinned version, take note that from release 4.0.0 all future changes will only be made to the `main` branch.
 
 ```hcl
 module "waf" {
   source = "umotif-public/waf-webaclv2/aws"
-  version = "~> 3.0.0"
+  version = "~> 4.0.0"
 
   name_prefix = "test-waf-setup"
   alb_arn     = module.alb.arn
@@ -250,7 +249,6 @@ module "waf" {
       priority = "9"
 
       override_action = "none"
-      excluded_rules = []
 
       visibility_config = {
         cloudwatch_metrics_enabled = false
@@ -288,7 +286,6 @@ module "waf" {
       priority = "9"
 
       override_action = "none"
-      excluded_rules = []
 
       visibility_config = {
         cloudwatch_metrics_enabled = false
@@ -370,7 +367,7 @@ module "waf" {
 provider "aws" {
   alias = "us-east"
 
-  version = ">= 3.38"
+  version = ">= 4.44.0"
   region  = "us-east-1"
 }
 
@@ -380,7 +377,7 @@ module "waf" {
   }
 
   source = "umotif-public/waf-webaclv2/aws"
-  version = "~> 3.0.0"
+  version = "~> 4.0.0"
 
   name_prefix = "test-waf-setup-cloudfront"
   scope = "CLOUDFRONT"
@@ -418,13 +415,13 @@ Module managed by:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.44.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.44.0 |
 
 ## Modules
 

--- a/examples/core/main.tf
+++ b/examples/core/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.7"
 
   required_providers {
-    aws = ">= 4.0.0"
+    aws = ">= 4.44.0"
   }
 }
 
@@ -59,7 +59,6 @@ module "waf" {
 
   rules = [
     {
-      # Uses optional excluded_rules to exclude certain managed rules
       name     = "AWSManagedRulesCommonRuleSet-rule-1"
       priority = "1"
 
@@ -74,11 +73,6 @@ module "waf" {
       managed_rule_group_statement = {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
-        excluded_rule = [
-          "SizeRestrictions_QUERYSTRING",
-          "SizeRestrictions_BODY",
-          "GenericRFI_QUERYARGUMENTS"
-        ]
       }
     },
     {

--- a/examples/wafv2-and-or-rules/main.tf
+++ b/examples/wafv2-and-or-rules/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.7"
 
   required_providers {
-    aws = ">= 4.0.0"
+    aws = ">= 4.44.0"
   }
 }
 
@@ -61,11 +61,6 @@ module "waf" {
       managed_rule_group_statement = {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
-        excluded_rule = [
-          "SizeRestrictions_QUERYSTRING",
-          "SizeRestrictions_BODY",
-          "GenericRFI_QUERYARGUMENTS"
-        ]
       }
     },
     {

--- a/examples/wafv2-bytematch-rules/main.tf
+++ b/examples/wafv2-bytematch-rules/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.7"
 
   required_providers {
-    aws = ">= 4.0.0"
+    aws = ">= 4.44.0"
   }
 }
 
@@ -46,11 +46,6 @@ module "waf" {
       managed_rule_group_statement = {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
-        excluded_rule = [
-          "SizeRestrictions_QUERYSTRING",
-          "SizeRestrictions_BODY",
-          "GenericRFI_QUERYARGUMENTS"
-        ]
       }
     },
     {

--- a/examples/wafv2-custom-json-response-managed-rule-group/main.tf
+++ b/examples/wafv2-custom-json-response-managed-rule-group/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.7"
 
   required_providers {
-    aws = ">= 4.0.0"
+    aws = ">= 4.44.0"
   }
 }
 

--- a/examples/wafv2-custom-response-code/main.tf
+++ b/examples/wafv2-custom-response-code/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.7"
 
   required_providers {
-    aws = ">= 4.0.0"
+    aws = ">= 4.44.0"
   }
 }
 
@@ -56,13 +56,7 @@ module "waf" {
 
       managed_rule_group_statement = {
         name        = "AWSManagedRulesBotControlRuleSet"
-        vendor_name = "AWS",
-        excluded_rule = [
-          "SignalNonBrowserUserAgent",
-          "CategoryHttpLibrary",
-          "SignalAutomatedBrowser",
-          "CategoryMonitoring"
-        ]
+        vendor_name = "AWS"
       }
 
       visibility_config = {

--- a/examples/wafv2-custom-response/main.tf
+++ b/examples/wafv2-custom-response/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.7"
 
   required_providers {
-    aws = ">= 4.0.0"
+    aws = ">= 4.44.0"
   }
 }
 
@@ -80,13 +80,7 @@ module "waf" {
 
       managed_rule_group_statement = {
         name        = "AWSManagedRulesBotControlRuleSet"
-        vendor_name = "AWS",
-        excluded_rule = [
-          "SignalNonBrowserUserAgent",
-          "CategoryHttpLibrary",
-          "SignalAutomatedBrowser",
-          "CategoryMonitoring"
-        ]
+        vendor_name = "AWS"
       }
 
       visibility_config = {

--- a/examples/wafv2-geo-rules/main.tf
+++ b/examples/wafv2-geo-rules/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.7"
 
   required_providers {
-    aws = ">= 4.0.0"
+    aws = ">= 4.44.0"
   }
 }
 
@@ -46,11 +46,6 @@ module "waf" {
       managed_rule_group_statement = {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
-        excluded_rule = [
-          "SizeRestrictions_QUERYSTRING",
-          "SizeRestrictions_BODY",
-          "GenericRFI_QUERYARGUMENTS"
-        ]
       }
     },
     {

--- a/examples/wafv2-ip-rules/main.tf
+++ b/examples/wafv2-ip-rules/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.7"
 
   required_providers {
-    aws = ">= 4.0.0"
+    aws = ">= 4.44.0"
   }
 }
 
@@ -69,11 +69,6 @@ module "waf" {
       managed_rule_group_statement = {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
-        excluded_rule = [
-          "SizeRestrictions_QUERYSTRING",
-          "SizeRestrictions_BODY",
-          "GenericRFI_QUERYARGUMENTS"
-        ]
       }
     },
     {

--- a/examples/wafv2-labelmatch-rules/main.tf
+++ b/examples/wafv2-labelmatch-rules/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.7"
 
   required_providers {
-    aws = ">= 4.0.0"
+    aws = ">= 4.44.0"
   }
 }
 
@@ -46,9 +46,6 @@ module "waf" {
       managed_rule_group_statement = {
         name        = "AWSManagedRulesBotControlRuleSet"
         vendor_name = "AWS"
-        excluded_rule = [
-          "SignalNonBrowserUserAgent"
-        ]
       }
     },
     {

--- a/examples/wafv2-logging-configuration/main.tf
+++ b/examples/wafv2-logging-configuration/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.7"
 
   required_providers {
-    aws = ">= 4.0.0"
+    aws = ">= 4.44.0"
   }
 }
 
@@ -185,11 +185,6 @@ module "wafv2" {
       managed_rule_group_statement = {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
-        excluded_rule = [
-          "SizeRestrictions_QUERYSTRING",
-          "SizeRestrictions_BODY",
-          "GenericRFI_QUERYARGUMENTS"
-        ]
       }
     },
     {

--- a/examples/wafv2-regex-pattern-rules/main.tf
+++ b/examples/wafv2-regex-pattern-rules/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.7"
 
   required_providers {
-    aws = ">= 4.0.0"
+    aws = ">= 4.44.0"
   }
 }
 

--- a/examples/wafv2-regexmatch-rules/main.tf
+++ b/examples/wafv2-regexmatch-rules/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.7"
 
   required_providers {
-    aws = ">= 4.0.0"
+    aws = ">= 4.44.0"
   }
 }
 

--- a/examples/wafv2-sizeconstraint-rules/main.tf
+++ b/examples/wafv2-sizeconstraint-rules/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.7"
 
   required_providers {
-    aws = ">= 4.0.0"
+    aws = ">= 4.44.0"
   }
 }
 
@@ -47,11 +47,6 @@ module "waf" {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
         version     = "Version_2.0"
-        excluded_rule = [
-          "SizeRestrictions_QUERYSTRING",
-          "SizeRestrictions_BODY",
-          "GenericRFI_QUERYARGUMENTS"
-        ]
       }
     },
     {

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.7"
 
   required_providers {
-    aws = ">= 4.0.0"
+    aws = ">= 4.44.0"
   }
 }


### PR DESCRIPTION
# Description

Updating documentation and examples to remove deprecated 'excluded_rule' due to [4.44.0](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v4.44.0) release 

