### PR TITLE
feat: action block captcha and challenge rules supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
-- Match Pattern Headers ([#1](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/1))
+- fix: typo
+- feat: action block cpatcha and chanllenge rules.
+- Fix: Match Pattern Headers ([#82](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/82))
 
 
 <a name="4.0.1"></a>

--- a/main.tf
+++ b/main.tf
@@ -51,6 +51,16 @@ resource "aws_wafv2_web_acl" "main" {
             content {}
           }
 
+          dynamic "captcha" {
+            for_each = lookup(rule.value, "action", {}) == "count" ? [1] : []
+            content {}
+          }
+
+          dynamic "challenge" {
+            for_each = lookup(rule.value, "action", {}) == "count" ? [1] : []
+            content {}
+          }
+
           dynamic "block" {
             for_each = lookup(rule.value, "action", {}) == "block" ? [1] : []
             content {

--- a/main.tf
+++ b/main.tf
@@ -52,12 +52,12 @@ resource "aws_wafv2_web_acl" "main" {
           }
 
           dynamic "captcha" {
-            for_each = lookup(rule.value, "action", {}) == "count" ? [1] : []
+            for_each = lookup(rule.value, "action", {}) == "captcha" ? [1] : []
             content {}
           }
 
           dynamic "challenge" {
-            for_each = lookup(rule.value, "action", {}) == "count" ? [1] : []
+            for_each = lookup(rule.value, "action", {}) == "challenge" ? [1] : []
             content {}
           }
 


### PR DESCRIPTION
# Description

Added ability to set captcha and challenge action rules. 

Here is the [resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl.html#captcha:~:text=The-,action,-block%20supports%20the) documentation for reference.
