### PR TITLE
Fix for headers field_to_match #94

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     args: ['--allow-missing-credentials']
   - id: trailing-whitespace
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.77.3
+  rev: v1.79.1
   hooks:
   - id: terraform_fmt
   - id: terraform_docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,21 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
-- Add scope down OR not_statements
-- chore: terraform fmt
+- fix
+- added example
+- revert array change
+- changed array output
+- changed array output
+- changed to match cookies
+- fixed for all header field matches
+- Small fix for 'field_to_match' to enable 'all' option'
+- adds managed rule group config block with bot control ([#93](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/93))
+
+
+<a name="4.3.0"></a>
+## [4.3.0] - 2023-04-28
+
+- Scope down OR not statements ([#97](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/97))
 
 
 <a name="4.2.0"></a>
@@ -268,7 +281,8 @@ dependency-type: indirect
 - Initial commit
 
 
-[Unreleased]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/4.2.0...HEAD
+[Unreleased]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/4.3.0...HEAD
+[4.3.0]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/4.2.0...4.3.0
 [4.2.0]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/4.1.2...4.2.0
 [4.1.2]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/4.1.1...4.1.2
 [4.1.1]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/4.1.0...4.1.1

--- a/examples/wafv2-bytematch-rules/main.tf
+++ b/examples/wafv2-bytematch-rules/main.tf
@@ -132,9 +132,36 @@ module "waf" {
       }
     },
     {
+      # Blocks requests which dont contain 'authorization' in any header key
+      name     = "block-unauthorized"
+      priority = "6"
+      action   = "block"
+      not_statement = {
+        byte_match_statement = {
+          field_to_match = {
+            headers = {
+              match_pattern = {
+                "all" = {}
+              }
+              match_scope = "Key"
+              override_action = "CONTINUE" 
+            }
+          }
+          positional_constraint = "CONTAINS"
+          search_string         = "authorization"
+          priority              = 0
+          type                  = "NONE" # The text transformation type
+        }
+      }
+      visibility_config = {
+        cloudwatch_metrics_enabled = false
+        sampled_requests_enabled   = false
+      }
+    },
+    {
       # Blocks a single user by checking the username header
       name     = "block-cookie"
-      priority = "6"
+      priority = "7"
       action   = "block"
 
       byte_match_statement = {

--- a/examples/wafv2-bytematch-rules/main.tf
+++ b/examples/wafv2-bytematch-rules/main.tf
@@ -143,8 +143,8 @@ module "waf" {
               match_pattern = {
                 "all" = {}
               }
-              match_scope = "Key"
-              oversize_handling = "CONTINUE" 
+              match_scope       = "Key"
+              oversize_handling = "CONTINUE"
             }
           }
           positional_constraint = "CONTAINS"
@@ -167,6 +167,8 @@ module "waf" {
       byte_match_statement = {
         field_to_match = {
           cookies = {
+            match_scope       = "KEY"
+            oversize_handling = "CONTINUE"
             match_pattern = {
               "all" = {}
             }

--- a/examples/wafv2-bytematch-rules/main.tf
+++ b/examples/wafv2-bytematch-rules/main.tf
@@ -144,7 +144,7 @@ module "waf" {
                 "all" = {}
               }
               match_scope = "Key"
-              override_action = "CONTINUE" 
+              oversize_handling = "CONTINUE" 
             }
           }
           positional_constraint = "CONTAINS"

--- a/main.tf
+++ b/main.tf
@@ -219,7 +219,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                  for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)

--- a/main.tf
+++ b/main.tf
@@ -130,16 +130,16 @@ resource "aws_wafv2_web_acl" "main" {
             version     = lookup(managed_rule_group_statement.value, "version", null)
 
             dynamic "managed_rule_group_configs" {
-                  for_each = length(lookup(managed_rule_group_statement.value, "managed_rule_group_configs", {})) == 0 ? [] : [lookup(managed_rule_group_statement.value, "managed_rule_group_configs", {})]
+              for_each = length(lookup(managed_rule_group_statement.value, "managed_rule_group_configs", {})) == 0 ? [] : [lookup(managed_rule_group_statement.value, "managed_rule_group_configs", {})]
+              content {
+                dynamic "aws_managed_rules_bot_control_rule_set" {
+                  for_each = length(lookup(managed_rule_group_configs.value, "aws_managed_rules_bot_control_rule_set", {})) == 0 ? [] : [lookup(managed_rule_group_configs.value, "aws_managed_rules_bot_control_rule_set", {})]
                   content {
-                    dynamic "aws_managed_rules_bot_control_rule_set" {
-                      for_each = length(lookup(managed_rule_group_configs.value, "aws_managed_rules_bot_control_rule_set", {})) == 0 ? [] : [lookup(managed_rule_group_configs.value, "aws_managed_rules_bot_control_rule_set", {})]
-                      content {
-                        inspection_level = lookup(aws_managed_rules_bot_control_rule_set.value, "inspection_level")
-                      }
-                    }
+                    inspection_level = lookup(aws_managed_rules_bot_control_rule_set.value, "inspection_level")
                   }
                 }
+              }
+            }
 
             dynamic "rule_action_override" {
               for_each = lookup(managed_rule_group_statement.value, "rule_action_overrides", null) == null ? [] : lookup(managed_rule_group_statement.value, "rule_action_overrides")
@@ -1802,7 +1802,8 @@ resource "aws_wafv2_web_acl" "main" {
                 dynamic "headers" {
                   for_each = length(lookup(field_to_match.value, "headers", {})) == 0 ? [] : [lookup(field_to_match.value, "headers")]
                   content {
-                    match_scope = upper(lookup(headers.value, "match_scope"))
+                    match_scope       = upper(lookup(headers.value, "match_scope"))
+                    oversize_handling = upper(lookup(headers.value, "oversize_handling"))
                     dynamic "match_pattern" {
                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                       content {
@@ -1814,7 +1815,7 @@ resource "aws_wafv2_web_acl" "main" {
                         excluded_headers = lookup(match_pattern.value, "excluded_headers", null)
                       }
                     }
-                    oversize_handling = upper(lookup(headers.value, "oversize_handling"))
+
                   }
                 }
               }

--- a/main.tf
+++ b/main.tf
@@ -219,7 +219,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -299,7 +299,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -413,7 +413,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -493,7 +493,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -588,7 +588,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -677,7 +677,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -757,7 +757,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -868,7 +868,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -965,7 +965,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                                for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1045,7 +1045,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                                for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1149,7 +1149,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                                for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1245,7 +1245,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1325,7 +1325,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1436,7 +1436,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1807,7 +1807,7 @@ resource "aws_wafv2_web_acl" "main" {
                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                       content {
                         dynamic "all" {
-                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                           content {}
                         }
                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1886,7 +1886,7 @@ resource "aws_wafv2_web_acl" "main" {
                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                       content {
                         dynamic "all" {
-                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                           content {}
                         }
                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2002,7 +2002,7 @@ resource "aws_wafv2_web_acl" "main" {
                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                       content {
                         dynamic "all" {
-                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                           content {}
                         }
                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2081,7 +2081,7 @@ resource "aws_wafv2_web_acl" "main" {
                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                       content {
                         dynamic "all" {
-                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                           content {}
                         }
                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2178,7 +2178,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2258,7 +2258,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2362,7 +2362,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2461,7 +2461,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     content {
 
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2541,7 +2541,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2655,7 +2655,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2735,7 +2735,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2878,7 +2878,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                                for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2958,7 +2958,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                                for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3076,7 +3076,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3156,7 +3156,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3280,7 +3280,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                                for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3360,7 +3360,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                                for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3480,7 +3480,7 @@ resource "aws_wafv2_web_acl" "main" {
                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                             content {
                               dynamic "all" {
-                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                 content {}
                               }
                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3560,7 +3560,7 @@ resource "aws_wafv2_web_acl" "main" {
                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                             content {
                               dynamic "all" {
-                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                 content {}
                               }
                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3680,7 +3680,7 @@ resource "aws_wafv2_web_acl" "main" {
                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                             content {
                               dynamic "all" {
-                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                 content {}
                               }
                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3770,7 +3770,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3850,7 +3850,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3970,7 +3970,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4054,7 +4054,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4134,7 +4134,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4254,7 +4254,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4349,7 +4349,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4429,7 +4429,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4549,7 +4549,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4632,7 +4632,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4712,7 +4712,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4832,7 +4832,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)

--- a/main.tf
+++ b/main.tf
@@ -219,7 +219,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -299,7 +299,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -413,7 +413,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -493,7 +493,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -588,7 +588,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -677,7 +677,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -757,7 +757,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -868,7 +868,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -965,7 +965,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1045,7 +1045,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1149,7 +1149,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1245,7 +1245,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1325,7 +1325,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1436,7 +1436,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1807,7 +1807,7 @@ resource "aws_wafv2_web_acl" "main" {
                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                       content {
                         dynamic "all" {
-                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                           content {}
                         }
                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1886,7 +1886,7 @@ resource "aws_wafv2_web_acl" "main" {
                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                       content {
                         dynamic "all" {
-                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                           content {}
                         }
                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2002,7 +2002,7 @@ resource "aws_wafv2_web_acl" "main" {
                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                       content {
                         dynamic "all" {
-                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                           content {}
                         }
                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2081,7 +2081,7 @@ resource "aws_wafv2_web_acl" "main" {
                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                       content {
                         dynamic "all" {
-                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                           content {}
                         }
                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2178,7 +2178,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2258,7 +2258,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2362,7 +2362,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2461,7 +2461,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     content {
 
                                       dynamic "all" {
-                                        for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2541,7 +2541,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2655,7 +2655,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2735,7 +2735,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2878,7 +2878,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2958,7 +2958,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3076,7 +3076,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3156,7 +3156,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3280,7 +3280,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3360,7 +3360,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3480,7 +3480,7 @@ resource "aws_wafv2_web_acl" "main" {
                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                             content {
                               dynamic "all" {
-                                for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                 content {}
                               }
                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3560,7 +3560,7 @@ resource "aws_wafv2_web_acl" "main" {
                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                             content {
                               dynamic "all" {
-                                for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                 content {}
                               }
                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3680,7 +3680,7 @@ resource "aws_wafv2_web_acl" "main" {
                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                             content {
                               dynamic "all" {
-                                for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                 content {}
                               }
                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3770,7 +3770,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3850,7 +3850,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3970,7 +3970,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4054,7 +4054,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4134,7 +4134,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4254,7 +4254,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4349,7 +4349,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4429,7 +4429,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4549,7 +4549,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4632,7 +4632,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4712,7 +4712,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4832,7 +4832,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)

--- a/main.tf
+++ b/main.tf
@@ -299,7 +299,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                  for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -413,7 +413,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                        for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -493,7 +493,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                        for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -588,7 +588,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                        for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -677,7 +677,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -757,7 +757,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -868,7 +868,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -965,7 +965,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                                for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1045,7 +1045,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                                for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1149,7 +1149,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                                for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1245,7 +1245,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1325,7 +1325,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1436,7 +1436,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1807,7 +1807,7 @@ resource "aws_wafv2_web_acl" "main" {
                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                       content {
                         dynamic "all" {
-                          for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                           content {}
                         }
                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1886,7 +1886,7 @@ resource "aws_wafv2_web_acl" "main" {
                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                       content {
                         dynamic "all" {
-                          for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                           content {}
                         }
                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2002,7 +2002,7 @@ resource "aws_wafv2_web_acl" "main" {
                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                       content {
                         dynamic "all" {
-                          for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                           content {}
                         }
                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2081,7 +2081,7 @@ resource "aws_wafv2_web_acl" "main" {
                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                       content {
                         dynamic "all" {
-                          for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                           content {}
                         }
                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2178,7 +2178,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                  for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2258,7 +2258,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                  for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2362,7 +2362,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                  for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2461,7 +2461,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     content {
 
                                       dynamic "all" {
-                                        for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                        for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2541,7 +2541,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                        for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2655,7 +2655,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2735,7 +2735,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2878,7 +2878,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                                for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2958,7 +2958,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                                for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3076,7 +3076,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3156,7 +3156,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                          for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3280,7 +3280,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                                for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3360,7 +3360,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                                for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3480,7 +3480,7 @@ resource "aws_wafv2_web_acl" "main" {
                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                             content {
                               dynamic "all" {
-                                for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                 content {}
                               }
                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3560,7 +3560,7 @@ resource "aws_wafv2_web_acl" "main" {
                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                             content {
                               dynamic "all" {
-                                for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                 content {}
                               }
                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3680,7 +3680,7 @@ resource "aws_wafv2_web_acl" "main" {
                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                             content {
                               dynamic "all" {
-                                for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                 content {}
                               }
                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3770,7 +3770,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                  for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3850,7 +3850,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                  for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3970,7 +3970,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                  for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4054,7 +4054,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                        for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4134,7 +4134,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                        for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4254,7 +4254,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                        for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4349,7 +4349,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                  for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4429,7 +4429,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                  for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4549,7 +4549,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                  for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4632,7 +4632,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                        for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4712,7 +4712,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                        for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4832,7 +4832,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                        for_each = length(lookup(keys(match_pattern.value), "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)

--- a/main.tf
+++ b/main.tf
@@ -219,7 +219,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -299,7 +299,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -413,7 +413,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -493,7 +493,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -588,7 +588,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -677,7 +677,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -757,7 +757,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -868,7 +868,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -965,7 +965,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1045,7 +1045,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1149,7 +1149,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1245,7 +1245,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1325,7 +1325,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1436,7 +1436,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1807,7 +1807,7 @@ resource "aws_wafv2_web_acl" "main" {
                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                       content {
                         dynamic "all" {
-                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                           content {}
                         }
                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1886,7 +1886,7 @@ resource "aws_wafv2_web_acl" "main" {
                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                       content {
                         dynamic "all" {
-                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                           content {}
                         }
                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2002,7 +2002,7 @@ resource "aws_wafv2_web_acl" "main" {
                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                       content {
                         dynamic "all" {
-                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                           content {}
                         }
                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2081,7 +2081,7 @@ resource "aws_wafv2_web_acl" "main" {
                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                       content {
                         dynamic "all" {
-                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                           content {}
                         }
                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2178,7 +2178,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2258,7 +2258,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2362,7 +2362,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2461,7 +2461,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     content {
 
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2541,7 +2541,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2655,7 +2655,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2735,7 +2735,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2878,7 +2878,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2958,7 +2958,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3076,7 +3076,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3156,7 +3156,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3280,7 +3280,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3360,7 +3360,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3480,7 +3480,7 @@ resource "aws_wafv2_web_acl" "main" {
                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                             content {
                               dynamic "all" {
-                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                 content {}
                               }
                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3560,7 +3560,7 @@ resource "aws_wafv2_web_acl" "main" {
                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                             content {
                               dynamic "all" {
-                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                 content {}
                               }
                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3680,7 +3680,7 @@ resource "aws_wafv2_web_acl" "main" {
                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                             content {
                               dynamic "all" {
-                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                 content {}
                               }
                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3770,7 +3770,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3850,7 +3850,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3970,7 +3970,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4054,7 +4054,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4134,7 +4134,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4254,7 +4254,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4349,7 +4349,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4429,7 +4429,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4549,7 +4549,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4632,7 +4632,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4712,7 +4712,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4832,7 +4832,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(keys(match_pattern.value), "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)

--- a/main.tf
+++ b/main.tf
@@ -219,7 +219,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -299,7 +299,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -413,7 +413,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -493,7 +493,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -588,7 +588,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -677,7 +677,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -757,7 +757,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -868,7 +868,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -965,7 +965,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1045,7 +1045,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1149,7 +1149,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1245,7 +1245,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1325,7 +1325,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1436,7 +1436,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1807,7 +1807,7 @@ resource "aws_wafv2_web_acl" "main" {
                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                       content {
                         dynamic "all" {
-                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                           content {}
                         }
                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -1886,7 +1886,7 @@ resource "aws_wafv2_web_acl" "main" {
                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                       content {
                         dynamic "all" {
-                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                           content {}
                         }
                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2002,7 +2002,7 @@ resource "aws_wafv2_web_acl" "main" {
                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                       content {
                         dynamic "all" {
-                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                           content {}
                         }
                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2081,7 +2081,7 @@ resource "aws_wafv2_web_acl" "main" {
                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                       content {
                         dynamic "all" {
-                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                           content {}
                         }
                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2178,7 +2178,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2258,7 +2258,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2362,7 +2362,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2461,7 +2461,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     content {
 
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2541,7 +2541,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2655,7 +2655,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2735,7 +2735,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2878,7 +2878,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -2958,7 +2958,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3076,7 +3076,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3156,7 +3156,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                       content {
                                         dynamic "all" {
-                                          for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                           content {}
                                         }
                                         included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3280,7 +3280,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3360,7 +3360,7 @@ resource "aws_wafv2_web_acl" "main" {
                                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                             content {
                                               dynamic "all" {
-                                                for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                                 content {}
                                               }
                                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3480,7 +3480,7 @@ resource "aws_wafv2_web_acl" "main" {
                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                             content {
                               dynamic "all" {
-                                for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                 content {}
                               }
                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3560,7 +3560,7 @@ resource "aws_wafv2_web_acl" "main" {
                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                             content {
                               dynamic "all" {
-                                for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                 content {}
                               }
                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3680,7 +3680,7 @@ resource "aws_wafv2_web_acl" "main" {
                             for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                             content {
                               dynamic "all" {
-                                for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                 content {}
                               }
                               included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3770,7 +3770,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3850,7 +3850,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -3970,7 +3970,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4054,7 +4054,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4134,7 +4134,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4254,7 +4254,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4349,7 +4349,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4429,7 +4429,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4549,7 +4549,7 @@ resource "aws_wafv2_web_acl" "main" {
                               for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                               content {
                                 dynamic "all" {
-                                  for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                   content {}
                                 }
                                 included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4632,7 +4632,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4712,7 +4712,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)
@@ -4832,7 +4832,7 @@ resource "aws_wafv2_web_acl" "main" {
                                     for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
                                     content {
                                       dynamic "all" {
-                                        for_each = contains(keys(match_pattern.value), "all") ? [contains(keys(match_pattern.value), "all")] : []
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
                                         content {}
                                       }
                                       included_headers = lookup(match_pattern.value, "included_headers", null)


### PR DESCRIPTION
# Description

Lookup for `field_to_match` in `headers` wasn't scanning keys.
This should fix the issue #94 


Please explain the changes you made here and link to any relevant issues.
Changed :
`lookup(match_pattern.value, "all", {}`
to:
`lookup(keys(match_pattern.value), "all", {}`
