### PR TITLE
Allow OR statement inside AND statement

### DIFF
--- a/examples/wafv2-and-or-rules/main.tf
+++ b/examples/wafv2-and-or-rules/main.tf
@@ -25,6 +25,25 @@ resource "aws_wafv2_ip_set" "custom_ip_set" {
   ]
 }
 
+resource "aws_wafv2_regex_pattern_set" "bad_bots_user_agent" {
+  name        = "BadBotsUserAgent"
+  description = "Some bots regex pattern set example"
+  scope       = "REGIONAL"
+
+  regular_expression {
+    regex_string = "semrushbot|censysinspect"
+  }
+
+  regular_expression {
+    regex_string = "blackwidow|acunetix-*"
+  }
+
+  tags = {
+    Name        = "RegexBadBots"
+    Environment = "WAFv2"
+  }
+}
+
 #####
 # Web Application Firewall configuration
 #####
@@ -76,6 +95,7 @@ module "waf" {
               field_to_match = {
                 uri_path = "{}"
               }
+
               positional_constraint = "STARTS_WITH"
               search_string         = "/path/to/match"
               priority              = 0
@@ -113,6 +133,7 @@ module "waf" {
               field_to_match = {
                 body = "{}"
               }
+
               positional_constraint = "CONTAINS"
               search_string         = "@hotmail.com"
               priority              = 0
@@ -129,8 +150,8 @@ module "waf" {
     },
     {
       ### AND rule example with NOT statement
-      name     = "block-specific-uri-path-and-requests-from-nl-gb-and-us"
-      priority = 2
+      name     = "block-specific-uri-path-and-not-requests-from-nl-gb-and-us"
+      priority = 4
       action   = "block"
 
       and_statement = {
@@ -140,6 +161,7 @@ module "waf" {
               field_to_match = {
                 uri_path = "{}"
               }
+
               positional_constraint = "STARTS_WITH"
               search_string         = "/path/to/match"
               priority              = 0
@@ -154,12 +176,13 @@ module "waf" {
           {
             not_statement = {
               regex_pattern_set_reference_statement = {
-                arn = aws_wafv2_ip_set.custom_regex_pattern_set.arn
+                arn = aws_wafv2_regex_pattern_set.bad_bots_user_agent.arn
                 field_to_match = {
                   single_header = {
                     name = "user-agent"
                   }
                 }
+
                 priority = 0
                 type     = "LOWERCASE" # The text transformation type
               }
@@ -173,6 +196,86 @@ module "waf" {
         sampled_requests_enabled   = false
       }
     },
+
+    {
+      #### AND rule with OR statement
+      name     = "block-specific-uri"
+      priority = 5
+      action   = "block"
+
+      rate_based_statement = {
+        aggregate_key_type = "IP"
+        limit              = 123
+
+        scope_down_statement = {
+          and_statement = {
+            statements = [
+              {
+                or_statement = {
+                  statements = [
+                    {
+                      byte_match_statement = {
+                        positional_constraint = "EXACTLY"
+                        search_string         = "some.url.com"
+
+                        field_to_match = {
+
+                          single_header = {
+                            name = "host"
+                          }
+                        }
+
+                        priority = 0
+                        type     = "NONE"
+                      }
+
+                    },
+                    {
+                      byte_match_statement = {
+                        positional_constraint = "EXACTLY"
+                        search_string         = "some.other.url.com"
+
+                        field_to_match = {
+                          single_header = {
+                            name = "host"
+                          }
+                        }
+
+                        priority = 0
+                        type     = "NONE"
+                      }
+
+                    }
+                  ]
+                }
+              },
+              {
+                byte_match_statement = {
+                  positional_constraint = "STARTS_WITH"
+                  search_string         = "/whatever"
+
+                  field_to_match = {
+
+                    uri_path = "{}"
+                  }
+
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+
+            ]
+          }
+        }
+      }
+
+      visibility_config = {
+        cloudwatch_metrics_enabled = false
+        sampled_requests_enabled   = false
+        metric_name                = "whatever-metric"
+
+      }
+    }
   ]
 
   tags = {

--- a/main.tf
+++ b/main.tf
@@ -808,7 +808,7 @@ resource "aws_wafv2_web_acl" "main" {
                           }
                         }
 
-                        #scope down AND regex_pattern_set_reference_statement
+                        # Scope down AND regex_pattern_set_reference_statement
                         dynamic "regex_pattern_set_reference_statement" {
                           for_each = length(lookup(statement.value, "regex_pattern_set_reference_statement", {})) == 0 ? [] : [lookup(statement.value, "regex_pattern_set_reference_statement", {})]
                           content {
@@ -887,6 +887,7 @@ resource "aws_wafv2_web_acl" "main" {
                           }
                         }
 
+                        # Scope down AND not_statement
                         dynamic "not_statement" {
                           for_each = length(lookup(statement.value, "not_statement", {})) == 0 ? [] : [lookup(statement.value, "not_statement", {})]
                           content {
@@ -1171,7 +1172,296 @@ resource "aws_wafv2_web_acl" "main" {
                           }
                         }
 
+                        # Scope down AND or_statement
+                        dynamic "or_statement" {
+                          for_each = length(lookup(statement.value, "or_statement", {})) == 0 ? [] : [lookup(statement.value, "or_statement", {})]
+                          content {
 
+                            dynamic "statement" {
+                              for_each = lookup(or_statement.value, "statements", {})
+                              content {
+
+                                # Scope down AND or_statement byte_match_statement
+                                dynamic "byte_match_statement" {
+                                  for_each = length(lookup(statement.value, "byte_match_statement", {})) == 0 ? [] : [lookup(statement.value, "byte_match_statement", {})]
+                                  content {
+                                    dynamic "field_to_match" {
+                                      for_each = length(lookup(byte_match_statement.value, "field_to_match", {})) == 0 ? [] : [lookup(byte_match_statement.value, "field_to_match", {})]
+                                      content {
+                                        dynamic "cookies" {
+                                          for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
+                                          content {
+                                            match_scope = lookup(cookies.value, "match_scope")
+                                            oversize_handling = lookup(cookies.value, "oversize_handling")
+                                            dynamic "match_pattern" {
+                                              for_each = [lookup(cookies.value, "match_pattern")]
+                                              content {
+                                                dynamic "all" {
+                                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                                  content {}
+                                                }
+                                                included_cookies = length(lookup(match_pattern.value, "included_cookies", [])) != 0 ? lookup(match_pattern.value, "included_cookies") : []
+                                                excluded_cookies = length(lookup(match_pattern.value, "excluded_cookies", [])) != 0 ? lookup(match_pattern.value, "excluded_cookies") : []
+                                              }
+                                            }
+                                          }
+                                        }
+                                        dynamic "uri_path" {
+                                          for_each = length(lookup(field_to_match.value, "uri_path", {})) == 0 ? [] : [lookup(field_to_match.value, "uri_path")]
+                                          content {}
+                                        }
+                                        dynamic "all_query_arguments" {
+                                          for_each = length(lookup(field_to_match.value, "all_query_arguments", {})) == 0 ? [] : [lookup(field_to_match.value, "all_query_arguments")]
+                                          content {}
+                                        }
+                                        dynamic "body" {
+                                          for_each = length(lookup(field_to_match.value, "body", {})) == 0 ? [] : [lookup(field_to_match.value, "body")]
+                                          content {}
+                                        }
+                                        dynamic "method" {
+                                          for_each = length(lookup(field_to_match.value, "method", {})) == 0 ? [] : [lookup(field_to_match.value, "method")]
+                                          content {}
+                                        }
+                                        dynamic "query_string" {
+                                          for_each = length(lookup(field_to_match.value, "query_string", {})) == 0 ? [] : [lookup(field_to_match.value, "query_string")]
+                                          content {}
+                                        }
+                                        dynamic "single_header" {
+                                          for_each = length(lookup(field_to_match.value, "single_header", {})) == 0 ? [] : [lookup(field_to_match.value, "single_header")]
+                                          content {
+                                            name = lower(lookup(single_header.value, "name"))
+                                          }
+                                        }
+                                        dynamic "headers" {
+                                          for_each = length(lookup(field_to_match.value, "headers", {})) == 0 ? [] : [lookup(field_to_match.value, "headers")]
+                                          content {
+                                            match_scope = upper(lookup(headers.value, "match_scope"))
+                                            dynamic "match_pattern" {
+                                              for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
+                                              content {
+                                                dynamic "all" {
+                                                  for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                                  content {}
+                                                }
+                                                included_headers = lookup(match_pattern.value, "included_headers", null)
+                                                excluded_headers = lookup(match_pattern.value, "excluded_headers", null)
+                                              }
+                                            }
+                                            oversize_handling = upper(lookup(headers.value, "oversize_handling"))
+                                          }
+                                        }
+                                      }
+                                    }
+                                    positional_constraint = lookup(byte_match_statement.value, "positional_constraint")
+                                    search_string         = lookup(byte_match_statement.value, "search_string")
+                                    text_transformation {
+                                      priority = lookup(byte_match_statement.value, "priority")
+                                      type     = lookup(byte_match_statement.value, "type")
+                                    }
+                                  }
+                                }
+
+                                # Scope down AND or_statement regex_match_statement
+                                dynamic "regex_match_statement" {
+                                  for_each = length(lookup(statement.value, "regex_match_statement", {})) == 0 ? [] : [lookup(statement.value, "regex_match_statement", {})]
+                                  content {
+                                    dynamic "field_to_match" {
+                                      for_each = length(lookup(regex_match_statement.value, "field_to_match", {})) == 0 ? [] : [lookup(regex_match_statement.value, "field_to_match", {})]
+                                      content {
+                                        dynamic "cookies" {
+                                          for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
+                                          content {
+                                            match_scope = lookup(cookies.value, "match_scope")
+                                            oversize_handling = lookup(cookies.value, "oversize_handling")
+                                            dynamic "match_pattern" {
+                                              for_each = [lookup(cookies.value, "match_pattern")]
+                                              content {
+                                                dynamic "all" {
+                                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                                  content {}
+                                                }
+                                                included_cookies = length(lookup(match_pattern.value, "included_cookies", [])) != 0 ? lookup(match_pattern.value, "included_cookies") : []
+                                                excluded_cookies = length(lookup(match_pattern.value, "excluded_cookies", [])) != 0 ? lookup(match_pattern.value, "excluded_cookies") : []
+                                              }
+                                            }
+                                          }
+                                        }
+                                        dynamic "uri_path" {
+                                          for_each = length(lookup(field_to_match.value, "uri_path", {})) == 0 ? [] : [lookup(field_to_match.value, "uri_path")]
+                                          content {}
+                                        }
+                                        dynamic "all_query_arguments" {
+                                          for_each = length(lookup(field_to_match.value, "all_query_arguments", {})) == 0 ? [] : [lookup(field_to_match.value, "all_query_arguments")]
+                                          content {}
+                                        }
+                                        dynamic "body" {
+                                          for_each = length(lookup(field_to_match.value, "body", {})) == 0 ? [] : [lookup(field_to_match.value, "body")]
+                                          content {}
+                                        }
+                                        dynamic "method" {
+                                          for_each = length(lookup(field_to_match.value, "method", {})) == 0 ? [] : [lookup(field_to_match.value, "method")]
+                                          content {}
+                                        }
+                                        dynamic "query_string" {
+                                          for_each = length(lookup(field_to_match.value, "query_string", {})) == 0 ? [] : [lookup(field_to_match.value, "query_string")]
+                                          content {}
+                                        }
+                                        dynamic "single_header" {
+                                          for_each = length(lookup(field_to_match.value, "single_header", {})) == 0 ? [] : [lookup(field_to_match.value, "single_header")]
+                                          content {
+                                            name = lower(lookup(single_header.value, "name"))
+                                          }
+                                        }
+                                        dynamic "headers" {
+                                          for_each = length(lookup(field_to_match.value, "headers", {})) == 0 ? [] : [lookup(field_to_match.value, "headers")]
+                                          content {
+                                            match_scope = upper(lookup(headers.value, "match_scope"))
+                                            dynamic "match_pattern" {
+                                              for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
+                                              content {
+                                                dynamic "all" {
+                                                  for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                                  content {}
+                                                }
+                                                included_headers = lookup(match_pattern.value, "included_headers", null)
+                                                excluded_headers = lookup(match_pattern.value, "excluded_headers", null)
+                                              }
+                                            }
+                                            oversize_handling = upper(lookup(headers.value, "oversize_handling"))
+                                          }
+                                        }
+                                      }
+                                    }
+                                    regex_string = lookup(regex_match_statement.value, "regex_string")
+                                    text_transformation {
+                                      priority = lookup(regex_match_statement.value, "priority")
+                                      type     = lookup(regex_match_statement.value, "type")
+                                    }
+                                  }
+                                }
+
+                                # Scope down AND or_statement geo_match_statement
+                                dynamic "geo_match_statement" {
+                                  for_each = length(lookup(statement.value, "geo_match_statement", {})) == 0 ? [] : [lookup(statement.value, "geo_match_statement", {})]
+                                  content {
+                                    country_codes = lookup(geo_match_statement.value, "country_codes")
+                                    dynamic "forwarded_ip_config" {
+                                      for_each = length(lookup(geo_match_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(geo_match_statement.value, "forwarded_ip_config", {})]
+                                      content {
+                                        fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
+                                        header_name       = lookup(forwarded_ip_config.value, "header_name")
+                                      }
+                                    }
+                                  }
+                                }
+
+                                # Scope down AND or_statement ip_set_statement
+                                dynamic "ip_set_reference_statement" {
+                                  for_each = length(lookup(statement.value, "ip_set_reference_statement", {})) == 0 ? [] : [lookup(statement.value, "ip_set_reference_statement", {})]
+                                  content {
+                                    arn = lookup(ip_set_reference_statement.value, "arn")
+                                    dynamic "ip_set_forwarded_ip_config" {
+                                      for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                                      content {
+                                        fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
+                                        header_name       = lookup(forwarded_ip_config.value, "header_name")
+                                        position          = lookup(forwarded_ip_config.value, "position")
+                                      }
+                                    }
+                                  }
+                                }
+
+                                # Scope down AND or_statement label_match_statement
+                                dynamic "label_match_statement" {
+                                  for_each = length(lookup(statement.value, "label_match_statement", {})) == 0 ? [] : [lookup(statement.value, "label_match_statement", {})]
+                                  content {
+                                    key   = lookup(label_match_statement.value, "key")
+                                    scope = lookup(label_match_statement.value, "scope")
+                                  }
+                                }
+
+                                # Scope down AND or_statement regex_pattern_set_reference_statement
+                                dynamic "regex_pattern_set_reference_statement" {
+                                  for_each = length(lookup(statement.value, "regex_pattern_set_reference_statement", {})) == 0 ? [] : [lookup(statement.value, "regex_pattern_set_reference_statement", {})]
+                                  content {
+                                    arn = lookup(regex_pattern_set_reference_statement.value, "arn")
+                                    dynamic "field_to_match" {
+                                      for_each = length(lookup(regex_pattern_set_reference_statement.value, "field_to_match", {})) == 0 ? [] : [lookup(regex_pattern_set_reference_statement.value, "field_to_match", {})]
+                                      content {
+                                        dynamic "cookies" {
+                                          for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
+                                          content {
+                                            match_scope = lookup(cookies.value, "match_scope")
+                                            oversize_handling = lookup(cookies.value, "oversize_handling")
+                                            dynamic "match_pattern" {
+                                              for_each = [lookup(cookies.value, "match_pattern")]
+                                              content {
+                                                dynamic "all" {
+                                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                                  content {}
+                                                }
+                                                included_cookies = length(lookup(match_pattern.value, "included_cookies", [])) != 0 ? lookup(match_pattern.value, "included_cookies") : []
+                                                excluded_cookies = length(lookup(match_pattern.value, "excluded_cookies", [])) != 0 ? lookup(match_pattern.value, "excluded_cookies") : []
+                                              }
+                                            }
+                                          }
+                                        }
+                                        dynamic "uri_path" {
+                                          for_each = length(lookup(field_to_match.value, "uri_path", {})) == 0 ? [] : [lookup(field_to_match.value, "uri_path")]
+                                          content {}
+                                        }
+                                        dynamic "all_query_arguments" {
+                                          for_each = length(lookup(field_to_match.value, "all_query_arguments", {})) == 0 ? [] : [lookup(field_to_match.value, "all_query_arguments")]
+                                          content {}
+                                        }
+                                        dynamic "body" {
+                                          for_each = length(lookup(field_to_match.value, "body", {})) == 0 ? [] : [lookup(field_to_match.value, "body")]
+                                          content {}
+                                        }
+                                        dynamic "method" {
+                                          for_each = length(lookup(field_to_match.value, "method", {})) == 0 ? [] : [lookup(field_to_match.value, "method")]
+                                          content {}
+                                        }
+                                        dynamic "query_string" {
+                                          for_each = length(lookup(field_to_match.value, "query_string", {})) == 0 ? [] : [lookup(field_to_match.value, "query_string")]
+                                          content {}
+                                        }
+                                        dynamic "single_header" {
+                                          for_each = length(lookup(field_to_match.value, "single_header", {})) == 0 ? [] : [lookup(field_to_match.value, "single_header")]
+                                          content {
+                                            name = lower(lookup(single_header.value, "name"))
+                                          }
+                                        }
+                                        dynamic "headers" {
+                                          for_each = length(lookup(field_to_match.value, "headers", {})) == 0 ? [] : [lookup(field_to_match.value, "headers")]
+                                          content {
+                                            match_scope = upper(lookup(headers.value, "match_scope"))
+                                            dynamic "match_pattern" {
+                                              for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
+                                              content {
+                                                dynamic "all" {
+                                                  for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                                  content {}
+                                                }
+                                                included_headers = lookup(match_pattern.value, "included_headers", null)
+                                                excluded_headers = lookup(match_pattern.value, "excluded_headers", null)
+                                              }
+                                            }
+                                            oversize_handling = upper(lookup(headers.value, "oversize_handling"))
+                                          }
+                                        }
+                                      }
+                                    }
+                                    text_transformation {
+                                      priority = lookup(regex_pattern_set_reference_statement.value, "priority")
+                                      type     = lookup(regex_pattern_set_reference_statement.value, "type")
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
                       }
                     }
                   }
@@ -2797,10 +3087,6 @@ resource "aws_wafv2_web_acl" "main" {
                         }
 
                         # Scope down AND not_statement
-
-                        #scope_down -> and_Statement -> statement -> not_statement -> statement -> ip_set
-
-
                         dynamic "not_statement" {
                           for_each = length(lookup(statement.value, "not_statement", {})) == 0 ? [] : [lookup(statement.value, "not_statement", {})]
                           content {
@@ -3000,6 +3286,297 @@ resource "aws_wafv2_web_acl" "main" {
                                 content {
                                   key   = lookup(label_match_statement.value, "key")
                                   scope = lookup(label_match_statement.value, "scope")
+                                }
+                              }
+                            }
+                          }
+                        }
+
+                        ### Scope down AND or_statement
+                        dynamic "or_statement" {
+                          for_each = length(lookup(statement.value, "or_statement", {})) == 0 ? [] : [lookup(statement.value, "or_statement", {})]
+                          content {
+
+                            dynamic "statement" {
+                              for_each = lookup(or_statement.value, "statements", {})
+                              content {
+
+                                # Scope down AND or_statement byte_match_statement
+                                dynamic "byte_match_statement" {
+                                  for_each = length(lookup(statement.value, "byte_match_statement", {})) == 0 ? [] : [lookup(statement.value, "byte_match_statement", {})]
+                                  content {
+                                    dynamic "field_to_match" {
+                                      for_each = length(lookup(byte_match_statement.value, "field_to_match", {})) == 0 ? [] : [lookup(byte_match_statement.value, "field_to_match", {})]
+                                      content {
+                                        dynamic "cookies" {
+                                          for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
+                                          content {
+                                            match_scope = lookup(cookies.value, "match_scope")
+                                            oversize_handling = lookup(cookies.value, "oversize_handling")
+                                            dynamic "match_pattern" {
+                                              for_each = [lookup(cookies.value, "match_pattern")]
+                                              content {
+                                                dynamic "all" {
+                                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                                  content {}
+                                                }
+                                                included_cookies = length(lookup(match_pattern.value, "included_cookies", [])) != 0 ? lookup(match_pattern.value, "included_cookies") : []
+                                                excluded_cookies = length(lookup(match_pattern.value, "excluded_cookies", [])) != 0 ? lookup(match_pattern.value, "excluded_cookies") : []
+                                              }
+                                            }
+                                          }
+                                        }
+                                        dynamic "uri_path" {
+                                          for_each = length(lookup(field_to_match.value, "uri_path", {})) == 0 ? [] : [lookup(field_to_match.value, "uri_path")]
+                                          content {}
+                                        }
+                                        dynamic "all_query_arguments" {
+                                          for_each = length(lookup(field_to_match.value, "all_query_arguments", {})) == 0 ? [] : [lookup(field_to_match.value, "all_query_arguments")]
+                                          content {}
+                                        }
+                                        dynamic "body" {
+                                          for_each = length(lookup(field_to_match.value, "body", {})) == 0 ? [] : [lookup(field_to_match.value, "body")]
+                                          content {}
+                                        }
+                                        dynamic "method" {
+                                          for_each = length(lookup(field_to_match.value, "method", {})) == 0 ? [] : [lookup(field_to_match.value, "method")]
+                                          content {}
+                                        }
+                                        dynamic "query_string" {
+                                          for_each = length(lookup(field_to_match.value, "query_string", {})) == 0 ? [] : [lookup(field_to_match.value, "query_string")]
+                                          content {}
+                                        }
+                                        dynamic "single_header" {
+                                          for_each = length(lookup(field_to_match.value, "single_header", {})) == 0 ? [] : [lookup(field_to_match.value, "single_header")]
+                                          content {
+                                            name = lower(lookup(single_header.value, "name"))
+                                          }
+                                        }
+                                        dynamic "headers" {
+                                          for_each = length(lookup(field_to_match.value, "headers", {})) == 0 ? [] : [lookup(field_to_match.value, "headers")]
+                                          content {
+                                            match_scope = upper(lookup(headers.value, "match_scope"))
+                                            dynamic "match_pattern" {
+                                              for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
+                                              content {
+                                                dynamic "all" {
+                                                  for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                                  content {}
+                                                }
+                                                included_headers = lookup(match_pattern.value, "included_headers", null)
+                                                excluded_headers = lookup(match_pattern.value, "excluded_headers", null)
+                                              }
+                                            }
+                                            oversize_handling = upper(lookup(headers.value, "oversize_handling"))
+                                          }
+                                        }
+                                      }
+                                    }
+                                    positional_constraint = lookup(byte_match_statement.value, "positional_constraint")
+                                    search_string         = lookup(byte_match_statement.value, "search_string")
+                                    text_transformation {
+                                      priority = lookup(byte_match_statement.value, "priority")
+                                      type     = lookup(byte_match_statement.value, "type")
+                                    }
+                                  }
+                                }
+
+                                # Scope down AND or_statement regex_match_statement
+                                dynamic "regex_match_statement" {
+                                  for_each = length(lookup(statement.value, "regex_match_statement", {})) == 0 ? [] : [lookup(statement.value, "regex_match_statement", {})]
+                                  content {
+                                    dynamic "field_to_match" {
+                                      for_each = length(lookup(regex_match_statement.value, "field_to_match", {})) == 0 ? [] : [lookup(regex_match_statement.value, "field_to_match", {})]
+                                      content {
+                                        dynamic "cookies" {
+                                          for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
+                                          content {
+                                            match_scope = lookup(cookies.value, "match_scope")
+                                            oversize_handling = lookup(cookies.value, "oversize_handling")
+                                            dynamic "match_pattern" {
+                                              for_each = [lookup(cookies.value, "match_pattern")]
+                                              content {
+                                                dynamic "all" {
+                                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                                  content {}
+                                                }
+                                                included_cookies = length(lookup(match_pattern.value, "included_cookies", [])) != 0 ? lookup(match_pattern.value, "included_cookies") : []
+                                                excluded_cookies = length(lookup(match_pattern.value, "excluded_cookies", [])) != 0 ? lookup(match_pattern.value, "excluded_cookies") : []
+                                              }
+                                            }
+                                          }
+                                        }
+                                        dynamic "uri_path" {
+                                          for_each = length(lookup(field_to_match.value, "uri_path", {})) == 0 ? [] : [lookup(field_to_match.value, "uri_path")]
+                                          content {}
+                                        }
+                                        dynamic "all_query_arguments" {
+                                          for_each = length(lookup(field_to_match.value, "all_query_arguments", {})) == 0 ? [] : [lookup(field_to_match.value, "all_query_arguments")]
+                                          content {}
+                                        }
+                                        dynamic "body" {
+                                          for_each = length(lookup(field_to_match.value, "body", {})) == 0 ? [] : [lookup(field_to_match.value, "body")]
+                                          content {}
+                                        }
+                                        dynamic "method" {
+                                          for_each = length(lookup(field_to_match.value, "method", {})) == 0 ? [] : [lookup(field_to_match.value, "method")]
+                                          content {}
+                                        }
+                                        dynamic "query_string" {
+                                          for_each = length(lookup(field_to_match.value, "query_string", {})) == 0 ? [] : [lookup(field_to_match.value, "query_string")]
+                                          content {}
+                                        }
+                                        dynamic "single_header" {
+                                          for_each = length(lookup(field_to_match.value, "single_header", {})) == 0 ? [] : [lookup(field_to_match.value, "single_header")]
+                                          content {
+                                            name = lower(lookup(single_header.value, "name"))
+                                          }
+                                        }
+                                        dynamic "headers" {
+                                          for_each = length(lookup(field_to_match.value, "headers", {})) == 0 ? [] : [lookup(field_to_match.value, "headers")]
+                                          content {
+                                            match_scope = upper(lookup(headers.value, "match_scope"))
+                                            dynamic "match_pattern" {
+                                              for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
+                                              content {
+                                                dynamic "all" {
+                                                  for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                                  content {}
+                                                }
+                                                included_headers = lookup(match_pattern.value, "included_headers", null)
+                                                excluded_headers = lookup(match_pattern.value, "excluded_headers", null)
+                                              }
+                                            }
+                                            oversize_handling = upper(lookup(headers.value, "oversize_handling"))
+                                          }
+                                        }
+                                      }
+                                    }
+                                    regex_string = lookup(regex_match_statement.value, "regex_string")
+                                    text_transformation {
+                                      priority = lookup(regex_match_statement.value, "priority")
+                                      type     = lookup(regex_match_statement.value, "type")
+                                    }
+                                  }
+                                }
+
+                                # Scope down AND or_statement geo_match_statement
+                                dynamic "geo_match_statement" {
+                                  for_each = length(lookup(statement.value, "geo_match_statement", {})) == 0 ? [] : [lookup(statement.value, "geo_match_statement", {})]
+                                  content {
+                                    country_codes = lookup(geo_match_statement.value, "country_codes")
+                                    dynamic "forwarded_ip_config" {
+                                      for_each = length(lookup(geo_match_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(geo_match_statement.value, "forwarded_ip_config", {})]
+                                      content {
+                                        fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
+                                        header_name       = lookup(forwarded_ip_config.value, "header_name")
+                                      }
+                                    }
+                                  }
+                                }
+
+                                # Scope down AND or_statement ip_set_statement
+                                dynamic "ip_set_reference_statement" {
+                                  for_each = length(lookup(statement.value, "ip_set_reference_statement", {})) == 0 ? [] : [lookup(statement.value, "ip_set_reference_statement", {})]
+                                  content {
+                                    arn = lookup(ip_set_reference_statement.value, "arn")
+                                    dynamic "ip_set_forwarded_ip_config" {
+                                      for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                                      content {
+                                        fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
+                                        header_name       = lookup(forwarded_ip_config.value, "header_name")
+                                        position          = lookup(forwarded_ip_config.value, "position")
+                                      }
+                                    }
+                                  }
+                                }
+
+                                # Scope down AND or_statement label_match_statement
+                                dynamic "label_match_statement" {
+                                  for_each = length(lookup(statement.value, "label_match_statement", {})) == 0 ? [] : [lookup(statement.value, "label_match_statement", {})]
+                                  content {
+                                    key   = lookup(label_match_statement.value, "key")
+                                    scope = lookup(label_match_statement.value, "scope")
+                                  }
+                                }
+
+                                # Scope down AND or_statement regex_pattern_set_reference_statement
+                                dynamic "regex_pattern_set_reference_statement" {
+                                  for_each = length(lookup(statement.value, "regex_pattern_set_reference_statement", {})) == 0 ? [] : [lookup(statement.value, "regex_pattern_set_reference_statement", {})]
+                                  content {
+                                    arn = lookup(regex_pattern_set_reference_statement.value, "arn")
+                                    dynamic "field_to_match" {
+                                      for_each = length(lookup(regex_pattern_set_reference_statement.value, "field_to_match", {})) == 0 ? [] : [lookup(regex_pattern_set_reference_statement.value, "field_to_match", {})]
+                                      content {
+                                        dynamic "cookies" {
+                                          for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
+                                          content {
+                                            match_scope = lookup(cookies.value, "match_scope")
+                                            oversize_handling = lookup(cookies.value, "oversize_handling")
+                                            dynamic "match_pattern" {
+                                              for_each = [lookup(cookies.value, "match_pattern")]
+                                              content {
+                                                dynamic "all" {
+                                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                                  content {}
+                                                }
+                                                included_cookies = length(lookup(match_pattern.value, "included_cookies", [])) != 0 ? lookup(match_pattern.value, "included_cookies") : []
+                                                excluded_cookies = length(lookup(match_pattern.value, "excluded_cookies", [])) != 0 ? lookup(match_pattern.value, "excluded_cookies") : []
+                                              }
+                                            }
+                                          }
+                                        }
+                                        dynamic "uri_path" {
+                                          for_each = length(lookup(field_to_match.value, "uri_path", {})) == 0 ? [] : [lookup(field_to_match.value, "uri_path")]
+                                          content {}
+                                        }
+                                        dynamic "all_query_arguments" {
+                                          for_each = length(lookup(field_to_match.value, "all_query_arguments", {})) == 0 ? [] : [lookup(field_to_match.value, "all_query_arguments")]
+                                          content {}
+                                        }
+                                        dynamic "body" {
+                                          for_each = length(lookup(field_to_match.value, "body", {})) == 0 ? [] : [lookup(field_to_match.value, "body")]
+                                          content {}
+                                        }
+                                        dynamic "method" {
+                                          for_each = length(lookup(field_to_match.value, "method", {})) == 0 ? [] : [lookup(field_to_match.value, "method")]
+                                          content {}
+                                        }
+                                        dynamic "query_string" {
+                                          for_each = length(lookup(field_to_match.value, "query_string", {})) == 0 ? [] : [lookup(field_to_match.value, "query_string")]
+                                          content {}
+                                        }
+                                        dynamic "single_header" {
+                                          for_each = length(lookup(field_to_match.value, "single_header", {})) == 0 ? [] : [lookup(field_to_match.value, "single_header")]
+                                          content {
+                                            name = lower(lookup(single_header.value, "name"))
+                                          }
+                                        }
+                                        dynamic "headers" {
+                                          for_each = length(lookup(field_to_match.value, "headers", {})) == 0 ? [] : [lookup(field_to_match.value, "headers")]
+                                          content {
+                                            match_scope = upper(lookup(headers.value, "match_scope"))
+                                            dynamic "match_pattern" {
+                                              for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
+                                              content {
+                                                dynamic "all" {
+                                                  for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                                  content {}
+                                                }
+                                                included_headers = lookup(match_pattern.value, "included_headers", null)
+                                                excluded_headers = lookup(match_pattern.value, "excluded_headers", null)
+                                              }
+                                            }
+                                            oversize_handling = upper(lookup(headers.value, "oversize_handling"))
+                                          }
+                                        }
+                                      }
+                                    }
+                                    text_transformation {
+                                      priority = lookup(regex_pattern_set_reference_statement.value, "priority")
+                                      type     = lookup(regex_pattern_set_reference_statement.value, "type")
+                                    }
+                                  }
                                 }
                               }
                             }
@@ -3990,7 +4567,6 @@ resource "aws_wafv2_web_acl" "main" {
                   }
                 }
 
-
                 ### AND not_statement
                 dynamic "not_statement" {
                   for_each = length(lookup(statement.value, "not_statement", {})) == 0 ? [] : [lookup(statement.value, "not_statement", {})]
@@ -4273,7 +4849,584 @@ resource "aws_wafv2_web_acl" "main" {
                           }
                         }
                       }
+                    }
+                  }
+                }
 
+                ### AND or_statement
+                dynamic "or_statement" {
+                  for_each = length(lookup(statement.value, "or_statement", {})) == 0 ? [] : [lookup(statement.value, "or_statement", {})]
+                  content {
+
+                    dynamic "statement" {
+                      for_each = lookup(or_statement.value, "statements", {})
+                      content {
+
+                        # AND or_statement byte_match_statement
+                        dynamic "byte_match_statement" {
+                          for_each = length(lookup(statement.value, "byte_match_statement", {})) == 0 ? [] : [lookup(statement.value, "byte_match_statement", {})]
+                          content {
+                            dynamic "field_to_match" {
+                              for_each = length(lookup(byte_match_statement.value, "field_to_match", {})) == 0 ? [] : [lookup(byte_match_statement.value, "field_to_match", {})]
+                              content {
+                                dynamic "cookies" {
+                                  for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
+                                  content {
+                                    match_scope = lookup(cookies.value, "match_scope")
+                                    oversize_handling = lookup(cookies.value, "oversize_handling")
+                                    dynamic "match_pattern" {
+                                      for_each = [lookup(cookies.value, "match_pattern")]
+                                      content {
+                                        dynamic "all" {
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                          content {}
+                                        }
+                                        included_cookies = length(lookup(match_pattern.value, "included_cookies", [])) != 0 ? lookup(match_pattern.value, "included_cookies") : []
+                                        excluded_cookies = length(lookup(match_pattern.value, "excluded_cookies", [])) != 0 ? lookup(match_pattern.value, "excluded_cookies") : []
+                                      }
+                                    }
+                                  }
+                                }
+                                dynamic "uri_path" {
+                                  for_each = length(lookup(field_to_match.value, "uri_path", {})) == 0 ? [] : [lookup(field_to_match.value, "uri_path")]
+                                  content {}
+                                }
+                                dynamic "all_query_arguments" {
+                                  for_each = length(lookup(field_to_match.value, "all_query_arguments", {})) == 0 ? [] : [lookup(field_to_match.value, "all_query_arguments")]
+                                  content {}
+                                }
+                                dynamic "body" {
+                                  for_each = length(lookup(field_to_match.value, "body", {})) == 0 ? [] : [lookup(field_to_match.value, "body")]
+                                  content {}
+                                }
+                                dynamic "method" {
+                                  for_each = length(lookup(field_to_match.value, "method", {})) == 0 ? [] : [lookup(field_to_match.value, "method")]
+                                  content {}
+                                }
+                                dynamic "query_string" {
+                                  for_each = length(lookup(field_to_match.value, "query_string", {})) == 0 ? [] : [lookup(field_to_match.value, "query_string")]
+                                  content {}
+                                }
+                                dynamic "single_header" {
+                                  for_each = length(lookup(field_to_match.value, "single_header", {})) == 0 ? [] : [lookup(field_to_match.value, "single_header")]
+                                  content {
+                                    name = lower(lookup(single_header.value, "name"))
+                                  }
+                                }
+                                dynamic "headers" {
+                                  for_each = length(lookup(field_to_match.value, "headers", {})) == 0 ? [] : [lookup(field_to_match.value, "headers")]
+                                  content {
+                                    match_scope = upper(lookup(headers.value, "match_scope"))
+                                    dynamic "match_pattern" {
+                                      for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
+                                      content {
+                                        dynamic "all" {
+                                          for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                          content {}
+                                        }
+                                        included_headers = lookup(match_pattern.value, "included_headers", null)
+                                        excluded_headers = lookup(match_pattern.value, "excluded_headers", null)
+                                      }
+                                    }
+                                    oversize_handling = upper(lookup(headers.value, "oversize_handling"))
+                                  }
+                                }
+                              }
+                            }
+                            positional_constraint = lookup(byte_match_statement.value, "positional_constraint")
+                            search_string         = lookup(byte_match_statement.value, "search_string")
+                            text_transformation {
+                              priority = lookup(byte_match_statement.value, "priority")
+                              type     = lookup(byte_match_statement.value, "type")
+                            }
+                          }
+                        }
+
+                        # AND or_statement regex_match_statement
+                        dynamic "regex_match_statement" {
+                          for_each = length(lookup(statement.value, "regex_match_statement", {})) == 0 ? [] : [lookup(statement.value, "regex_match_statement", {})]
+                          content {
+                            dynamic "field_to_match" {
+                              for_each = length(lookup(regex_match_statement.value, "field_to_match", {})) == 0 ? [] : [lookup(regex_match_statement.value, "field_to_match", {})]
+                              content {
+                                dynamic "cookies" {
+                                  for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
+                                  content {
+                                    match_scope = lookup(cookies.value, "match_scope")
+                                    oversize_handling = lookup(cookies.value, "oversize_handling")
+                                    dynamic "match_pattern" {
+                                      for_each = [lookup(cookies.value, "match_pattern")]
+                                      content {
+                                        dynamic "all" {
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                          content {}
+                                        }
+                                        included_cookies = length(lookup(match_pattern.value, "included_cookies", [])) != 0 ? lookup(match_pattern.value, "included_cookies") : []
+                                        excluded_cookies = length(lookup(match_pattern.value, "excluded_cookies", [])) != 0 ? lookup(match_pattern.value, "excluded_cookies") : []
+                                      }
+                                    }
+                                  }
+                                }
+                                dynamic "uri_path" {
+                                  for_each = length(lookup(field_to_match.value, "uri_path", {})) == 0 ? [] : [lookup(field_to_match.value, "uri_path")]
+                                  content {}
+                                }
+                                dynamic "all_query_arguments" {
+                                  for_each = length(lookup(field_to_match.value, "all_query_arguments", {})) == 0 ? [] : [lookup(field_to_match.value, "all_query_arguments")]
+                                  content {}
+                                }
+                                dynamic "body" {
+                                  for_each = length(lookup(field_to_match.value, "body", {})) == 0 ? [] : [lookup(field_to_match.value, "body")]
+                                  content {}
+                                }
+                                dynamic "method" {
+                                  for_each = length(lookup(field_to_match.value, "method", {})) == 0 ? [] : [lookup(field_to_match.value, "method")]
+                                  content {}
+                                }
+                                dynamic "query_string" {
+                                  for_each = length(lookup(field_to_match.value, "query_string", {})) == 0 ? [] : [lookup(field_to_match.value, "query_string")]
+                                  content {}
+                                }
+                                dynamic "single_header" {
+                                  for_each = length(lookup(field_to_match.value, "single_header", {})) == 0 ? [] : [lookup(field_to_match.value, "single_header")]
+                                  content {
+                                    name = lower(lookup(single_header.value, "name"))
+                                  }
+                                }
+                                dynamic "headers" {
+                                  for_each = length(lookup(field_to_match.value, "headers", {})) == 0 ? [] : [lookup(field_to_match.value, "headers")]
+                                  content {
+                                    match_scope = upper(lookup(headers.value, "match_scope"))
+                                    dynamic "match_pattern" {
+                                      for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
+                                      content {
+                                        dynamic "all" {
+                                          for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                          content {}
+                                        }
+                                        included_headers = lookup(match_pattern.value, "included_headers", null)
+                                        excluded_headers = lookup(match_pattern.value, "excluded_headers", null)
+                                      }
+                                    }
+                                    oversize_handling = upper(lookup(headers.value, "oversize_handling"))
+                                  }
+                                }
+                              }
+                            }
+                            regex_string = lookup(regex_match_statement.value, "regex_string")
+                            text_transformation {
+                              priority = lookup(regex_match_statement.value, "priority")
+                              type     = lookup(regex_match_statement.value, "type")
+                            }
+                          }
+                        }
+
+                        # AND or_statement geo_match_statement
+                        dynamic "geo_match_statement" {
+                          for_each = length(lookup(statement.value, "geo_match_statement", {})) == 0 ? [] : [lookup(statement.value, "geo_match_statement", {})]
+                          content {
+                            country_codes = lookup(geo_match_statement.value, "country_codes")
+                            dynamic "forwarded_ip_config" {
+                              for_each = length(lookup(geo_match_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(geo_match_statement.value, "forwarded_ip_config", {})]
+                              content {
+                                fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
+                                header_name       = lookup(forwarded_ip_config.value, "header_name")
+                              }
+                            }
+                          }
+                        }
+
+                        # AND or_statement ip_set_statement
+                        dynamic "ip_set_reference_statement" {
+                          for_each = length(lookup(statement.value, "ip_set_reference_statement", {})) == 0 ? [] : [lookup(statement.value, "ip_set_reference_statement", {})]
+                          content {
+                            arn = lookup(ip_set_reference_statement.value, "arn")
+                            dynamic "ip_set_forwarded_ip_config" {
+                              for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                              content {
+                                fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
+                                header_name       = lookup(forwarded_ip_config.value, "header_name")
+                                position          = lookup(forwarded_ip_config.value, "position")
+                              }
+                            }
+                          }
+                        }
+
+                        # AND or_statement label_match_statement
+                        dynamic "label_match_statement" {
+                          for_each = length(lookup(statement.value, "label_match_statement", {})) == 0 ? [] : [lookup(statement.value, "label_match_statement", {})]
+                          content {
+                            key   = lookup(label_match_statement.value, "key")
+                            scope = lookup(label_match_statement.value, "scope")
+                          }
+                        }
+
+                        # AND or_statement regex_pattern_set_reference_statement
+                        dynamic "regex_pattern_set_reference_statement" {
+                          for_each = length(lookup(statement.value, "regex_pattern_set_reference_statement", {})) == 0 ? [] : [lookup(statement.value, "regex_pattern_set_reference_statement", {})]
+                          content {
+                            arn = lookup(regex_pattern_set_reference_statement.value, "arn")
+                            dynamic "field_to_match" {
+                              for_each = length(lookup(regex_pattern_set_reference_statement.value, "field_to_match", {})) == 0 ? [] : [lookup(regex_pattern_set_reference_statement.value, "field_to_match", {})]
+                              content {
+                                dynamic "cookies" {
+                                  for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
+                                  content {
+                                    match_scope = lookup(cookies.value, "match_scope")
+                                    oversize_handling = lookup(cookies.value, "oversize_handling")
+                                    dynamic "match_pattern" {
+                                      for_each = [lookup(cookies.value, "match_pattern")]
+                                      content {
+                                        dynamic "all" {
+                                          for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                          content {}
+                                        }
+                                        included_cookies = length(lookup(match_pattern.value, "included_cookies", [])) != 0 ? lookup(match_pattern.value, "included_cookies") : []
+                                        excluded_cookies = length(lookup(match_pattern.value, "excluded_cookies", [])) != 0 ? lookup(match_pattern.value, "excluded_cookies") : []
+                                      }
+                                    }
+                                  }
+                                }
+                                dynamic "uri_path" {
+                                  for_each = length(lookup(field_to_match.value, "uri_path", {})) == 0 ? [] : [lookup(field_to_match.value, "uri_path")]
+                                  content {}
+                                }
+                                dynamic "all_query_arguments" {
+                                  for_each = length(lookup(field_to_match.value, "all_query_arguments", {})) == 0 ? [] : [lookup(field_to_match.value, "all_query_arguments")]
+                                  content {}
+                                }
+                                dynamic "body" {
+                                  for_each = length(lookup(field_to_match.value, "body", {})) == 0 ? [] : [lookup(field_to_match.value, "body")]
+                                  content {}
+                                }
+                                dynamic "method" {
+                                  for_each = length(lookup(field_to_match.value, "method", {})) == 0 ? [] : [lookup(field_to_match.value, "method")]
+                                  content {}
+                                }
+                                dynamic "query_string" {
+                                  for_each = length(lookup(field_to_match.value, "query_string", {})) == 0 ? [] : [lookup(field_to_match.value, "query_string")]
+                                  content {}
+                                }
+                                dynamic "single_header" {
+                                  for_each = length(lookup(field_to_match.value, "single_header", {})) == 0 ? [] : [lookup(field_to_match.value, "single_header")]
+                                  content {
+                                    name = lower(lookup(single_header.value, "name"))
+                                  }
+                                }
+                                dynamic "headers" {
+                                  for_each = length(lookup(field_to_match.value, "headers", {})) == 0 ? [] : [lookup(field_to_match.value, "headers")]
+                                  content {
+                                    match_scope = upper(lookup(headers.value, "match_scope"))
+                                    dynamic "match_pattern" {
+                                      for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
+                                      content {
+                                        dynamic "all" {
+                                          for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                          content {}
+                                        }
+                                        included_headers = lookup(match_pattern.value, "included_headers", null)
+                                        excluded_headers = lookup(match_pattern.value, "excluded_headers", null)
+                                      }
+                                    }
+                                    oversize_handling = upper(lookup(headers.value, "oversize_handling"))
+                                  }
+                                }
+                              }
+                            }
+                            text_transformation {
+                              priority = lookup(regex_pattern_set_reference_statement.value, "priority")
+                              type     = lookup(regex_pattern_set_reference_statement.value, "type")
+                            }
+                          }
+                        }
+
+                        # AND or_statement not_statement
+                        dynamic "not_statement" {
+                          for_each = length(lookup(statement.value, "not_statement", {})) == 0 ? [] : [lookup(statement.value, "not_statement", {})]
+                          content {
+                            statement {
+                              # OR not_statement byte_match_statement
+                              dynamic "byte_match_statement" {
+                                for_each = length(lookup(not_statement.value, "byte_match_statement", {})) == 0 ? [] : [lookup(not_statement.value, "byte_match_statement", {})]
+                                content {
+                                  dynamic "field_to_match" {
+                                    for_each = length(lookup(byte_match_statement.value, "field_to_match", {})) == 0 ? [] : [lookup(byte_match_statement.value, "field_to_match", {})]
+                                    content {
+                                      dynamic "cookies" {
+                                        for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
+                                        content {
+                                          match_scope = lookup(cookies.value, "match_scope")
+                                          oversize_handling = lookup(cookies.value, "oversize_handling")
+                                          dynamic "match_pattern" {
+                                            for_each = [lookup(cookies.value, "match_pattern")]
+                                            content {
+                                              dynamic "all" {
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                                content {}
+                                              }
+                                              included_cookies = length(lookup(match_pattern.value, "included_cookies", [])) != 0 ? lookup(match_pattern.value, "included_cookies") : []
+                                              excluded_cookies = length(lookup(match_pattern.value, "excluded_cookies", [])) != 0 ? lookup(match_pattern.value, "excluded_cookies") : []
+                                            }
+                                          }
+                                        }
+                                      }
+                                      dynamic "uri_path" {
+                                        for_each = length(lookup(field_to_match.value, "uri_path", {})) == 0 ? [] : [lookup(field_to_match.value, "uri_path")]
+                                        content {}
+                                      }
+                                      dynamic "all_query_arguments" {
+                                        for_each = length(lookup(field_to_match.value, "all_query_arguments", {})) == 0 ? [] : [lookup(field_to_match.value, "all_query_arguments")]
+                                        content {}
+                                      }
+                                      dynamic "body" {
+                                        for_each = length(lookup(field_to_match.value, "body", {})) == 0 ? [] : [lookup(field_to_match.value, "body")]
+                                        content {}
+                                      }
+                                      dynamic "method" {
+                                        for_each = length(lookup(field_to_match.value, "method", {})) == 0 ? [] : [lookup(field_to_match.value, "method")]
+                                        content {}
+                                      }
+                                      dynamic "query_string" {
+                                        for_each = length(lookup(field_to_match.value, "query_string", {})) == 0 ? [] : [lookup(field_to_match.value, "query_string")]
+                                        content {}
+                                      }
+                                      dynamic "single_header" {
+                                        for_each = length(lookup(field_to_match.value, "single_header", {})) == 0 ? [] : [lookup(field_to_match.value, "single_header")]
+                                        content {
+                                          name = lower(lookup(single_header.value, "name"))
+                                        }
+                                      }
+                                      dynamic "headers" {
+                                        for_each = length(lookup(field_to_match.value, "headers", {})) == 0 ? [] : [lookup(field_to_match.value, "headers")]
+                                        content {
+                                          match_scope = upper(lookup(headers.value, "match_scope"))
+                                          dynamic "match_pattern" {
+                                            for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
+                                            content {
+                                              dynamic "all" {
+                                                for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                                content {}
+                                              }
+                                              included_headers = lookup(match_pattern.value, "included_headers", null)
+                                              excluded_headers = lookup(match_pattern.value, "excluded_headers", null)
+                                            }
+                                          }
+                                          oversize_handling = upper(lookup(headers.value, "oversize_handling"))
+                                        }
+                                      }
+                                    }
+                                  }
+                                  positional_constraint = lookup(byte_match_statement.value, "positional_constraint")
+                                  search_string         = lookup(byte_match_statement.value, "search_string")
+                                  text_transformation {
+                                    priority = lookup(byte_match_statement.value, "priority")
+                                    type     = lookup(byte_match_statement.value, "type")
+                                  }
+                                }
+                              }
+
+                              # OR not_statement regex_match_statement
+                              dynamic "regex_match_statement" {
+                                for_each = length(lookup(not_statement.value, "regex_match_statement", {})) == 0 ? [] : [lookup(not_statement.value, "regex_match_statement", {})]
+                                content {
+                                  dynamic "field_to_match" {
+                                    for_each = length(lookup(regex_match_statement.value, "field_to_match", {})) == 0 ? [] : [lookup(regex_match_statement.value, "field_to_match", {})]
+                                    content {
+                                      dynamic "cookies" {
+                                        for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
+                                        content {
+                                          match_scope = lookup(cookies.value, "match_scope")
+                                          oversize_handling = lookup(cookies.value, "oversize_handling")
+                                          dynamic "match_pattern" {
+                                            for_each = [lookup(cookies.value, "match_pattern")]
+                                            content {
+                                              dynamic "all" {
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                                content {}
+                                              }
+                                              included_cookies = length(lookup(match_pattern.value, "included_cookies", [])) != 0 ? lookup(match_pattern.value, "included_cookies") : []
+                                              excluded_cookies = length(lookup(match_pattern.value, "excluded_cookies", [])) != 0 ? lookup(match_pattern.value, "excluded_cookies") : []
+                                            }
+                                          }
+                                        }
+                                      }
+                                      dynamic "uri_path" {
+                                        for_each = length(lookup(field_to_match.value, "uri_path", {})) == 0 ? [] : [lookup(field_to_match.value, "uri_path")]
+                                        content {}
+                                      }
+                                      dynamic "all_query_arguments" {
+                                        for_each = length(lookup(field_to_match.value, "all_query_arguments", {})) == 0 ? [] : [lookup(field_to_match.value, "all_query_arguments")]
+                                        content {}
+                                      }
+                                      dynamic "body" {
+                                        for_each = length(lookup(field_to_match.value, "body", {})) == 0 ? [] : [lookup(field_to_match.value, "body")]
+                                        content {}
+                                      }
+                                      dynamic "method" {
+                                        for_each = length(lookup(field_to_match.value, "method", {})) == 0 ? [] : [lookup(field_to_match.value, "method")]
+                                        content {}
+                                      }
+                                      dynamic "query_string" {
+                                        for_each = length(lookup(field_to_match.value, "query_string", {})) == 0 ? [] : [lookup(field_to_match.value, "query_string")]
+                                        content {}
+                                      }
+                                      dynamic "single_header" {
+                                        for_each = length(lookup(field_to_match.value, "single_header", {})) == 0 ? [] : [lookup(field_to_match.value, "single_header")]
+                                        content {
+                                          name = lower(lookup(single_header.value, "name"))
+                                        }
+                                      }
+                                      dynamic "headers" {
+                                        for_each = length(lookup(field_to_match.value, "headers", {})) == 0 ? [] : [lookup(field_to_match.value, "headers")]
+                                        content {
+                                          match_scope = upper(lookup(headers.value, "match_scope"))
+                                          dynamic "match_pattern" {
+                                            for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
+                                            content {
+                                              dynamic "all" {
+                                                for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                                content {}
+                                              }
+                                              included_headers = lookup(match_pattern.value, "included_headers", null)
+                                              excluded_headers = lookup(match_pattern.value, "excluded_headers", null)
+                                            }
+                                          }
+                                          oversize_handling = upper(lookup(headers.value, "oversize_handling"))
+                                        }
+                                      }
+                                    }
+                                  }
+                                  regex_string = lookup(regex_match_statement.value, "regex_string")
+                                  text_transformation {
+                                    priority = lookup(regex_match_statement.value, "priority")
+                                    type     = lookup(regex_match_statement.value, "type")
+                                  }
+                                }
+                              }
+
+                              # OR not_statement geo_match_statement
+                              dynamic "geo_match_statement" {
+                                for_each = length(lookup(not_statement.value, "geo_match_statement", {})) == 0 ? [] : [lookup(not_statement.value, "geo_match_statement", {})]
+                                content {
+                                  country_codes = lookup(geo_match_statement.value, "country_codes")
+                                  dynamic "forwarded_ip_config" {
+                                    for_each = length(lookup(geo_match_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(geo_match_statement.value, "forwarded_ip_config", {})]
+                                    content {
+                                      fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
+                                      header_name       = lookup(forwarded_ip_config.value, "header_name")
+                                    }
+                                  }
+                                }
+                              }
+
+                              # OR not_statement ip_set_statement
+                              dynamic "ip_set_reference_statement" {
+                                for_each = length(lookup(not_statement.value, "ip_set_reference_statement", {})) == 0 ? [] : [lookup(not_statement.value, "ip_set_reference_statement", {})]
+                                content {
+                                  arn = lookup(ip_set_reference_statement.value, "arn")
+                                  dynamic "ip_set_forwarded_ip_config" {
+                                    for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                                    content {
+                                      fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
+                                      header_name       = lookup(forwarded_ip_config.value, "header_name")
+                                      position          = lookup(forwarded_ip_config.value, "position")
+                                    }
+                                  }
+                                }
+                              }
+
+                              # OR not_statement label_match_statement
+                              dynamic "label_match_statement" {
+                                for_each = length(lookup(not_statement.value, "label_match_statement", {})) == 0 ? [] : [lookup(not_statement.value, "label_match_statement", {})]
+                                content {
+                                  key   = lookup(label_match_statement.value, "key")
+                                  scope = lookup(label_match_statement.value, "scope")
+                                }
+                              }
+
+                              # OR not_statement regex_pattern_set_reference_statement
+                              dynamic "regex_pattern_set_reference_statement" {
+                                for_each = length(lookup(not_statement.value, "regex_pattern_set_reference_statement", {})) == 0 ? [] : [lookup(not_statement.value, "regex_pattern_set_reference_statement", {})]
+                                content {
+                                  arn = lookup(regex_pattern_set_reference_statement.value, "arn")
+                                  dynamic "field_to_match" {
+                                    for_each = length(lookup(regex_pattern_set_reference_statement.value, "field_to_match", {})) == 0 ? [] : [lookup(regex_pattern_set_reference_statement.value, "field_to_match", {})]
+                                    content {
+                                      dynamic "cookies" {
+                                        for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
+                                        content {
+                                          match_scope = lookup(cookies.value, "match_scope")
+                                          oversize_handling = lookup(cookies.value, "oversize_handling")
+                                          dynamic "match_pattern" {
+                                            for_each = [lookup(cookies.value, "match_pattern")]
+                                            content {
+                                              dynamic "all" {
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                                content {}
+                                              }
+                                              included_cookies = length(lookup(match_pattern.value, "included_cookies", [])) != 0 ? lookup(match_pattern.value, "included_cookies") : []
+                                              excluded_cookies = length(lookup(match_pattern.value, "excluded_cookies", [])) != 0 ? lookup(match_pattern.value, "excluded_cookies") : []
+                                            }
+                                          }
+                                        }
+                                      }
+                                      dynamic "uri_path" {
+                                        for_each = length(lookup(field_to_match.value, "uri_path", {})) == 0 ? [] : [lookup(field_to_match.value, "uri_path")]
+                                        content {}
+                                      }
+                                      dynamic "all_query_arguments" {
+                                        for_each = length(lookup(field_to_match.value, "all_query_arguments", {})) == 0 ? [] : [lookup(field_to_match.value, "all_query_arguments")]
+                                        content {}
+                                      }
+                                      dynamic "body" {
+                                        for_each = length(lookup(field_to_match.value, "body", {})) == 0 ? [] : [lookup(field_to_match.value, "body")]
+                                        content {}
+                                      }
+                                      dynamic "method" {
+                                        for_each = length(lookup(field_to_match.value, "method", {})) == 0 ? [] : [lookup(field_to_match.value, "method")]
+                                        content {}
+                                      }
+                                      dynamic "query_string" {
+                                        for_each = length(lookup(field_to_match.value, "query_string", {})) == 0 ? [] : [lookup(field_to_match.value, "query_string")]
+                                        content {}
+                                      }
+                                      dynamic "single_header" {
+                                        for_each = length(lookup(field_to_match.value, "single_header", {})) == 0 ? [] : [lookup(field_to_match.value, "single_header")]
+                                        content {
+                                          name = lower(lookup(single_header.value, "name"))
+                                        }
+                                      }
+                                      dynamic "headers" {
+                                        for_each = length(lookup(field_to_match.value, "headers", {})) == 0 ? [] : [lookup(field_to_match.value, "headers")]
+                                        content {
+                                          match_scope = upper(lookup(headers.value, "match_scope"))
+                                          dynamic "match_pattern" {
+                                            for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
+                                            content {
+                                              dynamic "all" {
+                                                for_each = length(lookup(match_pattern.value, "all", {})) == 0 ? [] : [lookup(match_pattern.value, "all")]
+                                                content {}
+                                              }
+                                              included_headers = lookup(match_pattern.value, "included_headers", null)
+                                              excluded_headers = lookup(match_pattern.value, "excluded_headers", null)
+                                            }
+                                          }
+                                          oversize_handling = upper(lookup(headers.value, "oversize_handling"))
+                                        }
+                                      }
+                                    }
+                                  }
+                                  text_transformation {
+                                    priority = lookup(regex_pattern_set_reference_statement.value, "priority")
+                                    type     = lookup(regex_pattern_set_reference_statement.value, "type")
+                                  }
+                                }
+                              }
+
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 }

--- a/main.tf
+++ b/main.tf
@@ -1191,7 +1191,7 @@ resource "aws_wafv2_web_acl" "main" {
                                         dynamic "cookies" {
                                           for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
                                           content {
-                                            match_scope = lookup(cookies.value, "match_scope")
+                                            match_scope       = lookup(cookies.value, "match_scope")
                                             oversize_handling = lookup(cookies.value, "oversize_handling")
                                             dynamic "match_pattern" {
                                               for_each = [lookup(cookies.value, "match_pattern")]
@@ -1271,7 +1271,7 @@ resource "aws_wafv2_web_acl" "main" {
                                         dynamic "cookies" {
                                           for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
                                           content {
-                                            match_scope = lookup(cookies.value, "match_scope")
+                                            match_scope       = lookup(cookies.value, "match_scope")
                                             oversize_handling = lookup(cookies.value, "oversize_handling")
                                             dynamic "match_pattern" {
                                               for_each = [lookup(cookies.value, "match_pattern")]
@@ -1391,7 +1391,7 @@ resource "aws_wafv2_web_acl" "main" {
                                         dynamic "cookies" {
                                           for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
                                           content {
-                                            match_scope = lookup(cookies.value, "match_scope")
+                                            match_scope       = lookup(cookies.value, "match_scope")
                                             oversize_handling = lookup(cookies.value, "oversize_handling")
                                             dynamic "match_pattern" {
                                               for_each = [lookup(cookies.value, "match_pattern")]
@@ -3311,7 +3311,7 @@ resource "aws_wafv2_web_acl" "main" {
                                         dynamic "cookies" {
                                           for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
                                           content {
-                                            match_scope = lookup(cookies.value, "match_scope")
+                                            match_scope       = lookup(cookies.value, "match_scope")
                                             oversize_handling = lookup(cookies.value, "oversize_handling")
                                             dynamic "match_pattern" {
                                               for_each = [lookup(cookies.value, "match_pattern")]
@@ -3391,7 +3391,7 @@ resource "aws_wafv2_web_acl" "main" {
                                         dynamic "cookies" {
                                           for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
                                           content {
-                                            match_scope = lookup(cookies.value, "match_scope")
+                                            match_scope       = lookup(cookies.value, "match_scope")
                                             oversize_handling = lookup(cookies.value, "oversize_handling")
                                             dynamic "match_pattern" {
                                               for_each = [lookup(cookies.value, "match_pattern")]
@@ -3511,7 +3511,7 @@ resource "aws_wafv2_web_acl" "main" {
                                         dynamic "cookies" {
                                           for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
                                           content {
-                                            match_scope = lookup(cookies.value, "match_scope")
+                                            match_scope       = lookup(cookies.value, "match_scope")
                                             oversize_handling = lookup(cookies.value, "oversize_handling")
                                             dynamic "match_pattern" {
                                               for_each = [lookup(cookies.value, "match_pattern")]
@@ -4872,7 +4872,7 @@ resource "aws_wafv2_web_acl" "main" {
                                 dynamic "cookies" {
                                   for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
                                   content {
-                                    match_scope = lookup(cookies.value, "match_scope")
+                                    match_scope       = lookup(cookies.value, "match_scope")
                                     oversize_handling = lookup(cookies.value, "oversize_handling")
                                     dynamic "match_pattern" {
                                       for_each = [lookup(cookies.value, "match_pattern")]
@@ -4952,7 +4952,7 @@ resource "aws_wafv2_web_acl" "main" {
                                 dynamic "cookies" {
                                   for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
                                   content {
-                                    match_scope = lookup(cookies.value, "match_scope")
+                                    match_scope       = lookup(cookies.value, "match_scope")
                                     oversize_handling = lookup(cookies.value, "oversize_handling")
                                     dynamic "match_pattern" {
                                       for_each = [lookup(cookies.value, "match_pattern")]
@@ -5072,7 +5072,7 @@ resource "aws_wafv2_web_acl" "main" {
                                 dynamic "cookies" {
                                   for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
                                   content {
-                                    match_scope = lookup(cookies.value, "match_scope")
+                                    match_scope       = lookup(cookies.value, "match_scope")
                                     oversize_handling = lookup(cookies.value, "oversize_handling")
                                     dynamic "match_pattern" {
                                       for_each = [lookup(cookies.value, "match_pattern")]
@@ -5155,7 +5155,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       dynamic "cookies" {
                                         for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
                                         content {
-                                          match_scope = lookup(cookies.value, "match_scope")
+                                          match_scope       = lookup(cookies.value, "match_scope")
                                           oversize_handling = lookup(cookies.value, "oversize_handling")
                                           dynamic "match_pattern" {
                                             for_each = [lookup(cookies.value, "match_pattern")]
@@ -5235,7 +5235,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       dynamic "cookies" {
                                         for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
                                         content {
-                                          match_scope = lookup(cookies.value, "match_scope")
+                                          match_scope       = lookup(cookies.value, "match_scope")
                                           oversize_handling = lookup(cookies.value, "oversize_handling")
                                           dynamic "match_pattern" {
                                             for_each = [lookup(cookies.value, "match_pattern")]
@@ -5355,7 +5355,7 @@ resource "aws_wafv2_web_acl" "main" {
                                       dynamic "cookies" {
                                         for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
                                         content {
-                                          match_scope = lookup(cookies.value, "match_scope")
+                                          match_scope       = lookup(cookies.value, "match_scope")
                                           oversize_handling = lookup(cookies.value, "oversize_handling")
                                           dynamic "match_pattern" {
                                             for_each = [lookup(cookies.value, "match_pattern")]


### PR DESCRIPTION
# Description

Hi,

I faced the issue where I couldn't add an OR statement inside an AND statement. And seeing [issue #61](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/61), it seems that I'm not the only one.

This PR adds the OR statement (the code was copied from the original OR statement) inside all ANDs that I could find in the code. Some ANDs do not support the NOT clause in the OR, therefore, I've removed it.
```
╷
│ Error: Unsupported block type
│
│   on umotif-public/main.tf line 1451, in resource "aws_wafv2_web_acl" "main":
│ 1451:                                 dynamic "not_statement" {
│
│ Blocks of type "not_statement" are not expected here.
╵
```

I've tested the module on my particular use case (a redirect) and it seems to work, looking at the plan output.
```
 + rule {
          + name     = "<whatever>"
          + priority = 7

          + action {

              + block {
                }
            }

          + statement {

              + rate_based_statement {
                  + aggregate_key_type = "IP"
                  + limit              = 123

                  + scope_down_statement {
                      + and_statement {
                          + statement {

                              + or_statement {
                                  + statement {
                                      + byte_match_statement {
                                          + positional_constraint = "EXACTLY"
                                          + search_string         = "some.url.com"

                                          + field_to_match {

                                              + single_header {
                                                  + name = "host"
                                                }
                                            }

                                          + text_transformation {
                                              + priority = 0
                                              + type     = "NONE"
                                            }
                                        }
                                    }
                                  + statement {
                                      + byte_match_statement {
                                          + positional_constraint = "EXACTLY"
                                          + search_string         = "some.other.url.com"

                                          + field_to_match {
                                            + single_header {
                                                  + name = "host"
                                                }
                                            }

                                          + text_transformation {
                                              + priority = 0
                                              + type     = "NONE"
                                            }
                                        }
                                    }
                                }
                            }
                          + statement {

                              + byte_match_statement {
                                  + positional_constraint = "STARTS_WITH"
                                  + search_string         = "/<whatever>"

                                  + field_to_match {

                                      + uri_path {}
                                    }

                                  + text_transformation {
                                      + priority = 0
                                      + type     = "NONE"
                                    }
                                }
                            }
                        }
                    }
                }
            }

          + visibility_config {
              + cloudwatch_metrics_enabled = true
              + metric_name                = "<whatever>-metric"
              + sampled_requests_enabled   = true
            }
        }
```

Please review. Thanks.