### PR TITLE
Fix 'Invalid value for "inputMap" parameter: the given object has no attribute "type"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2530,7 +2530,7 @@ resource "aws_wafv2_web_acl" "main" {
             }
 
             dynamic "scope_down_statement" {
-              for_each = length(lookup(rate_based_statement.value, "scope_down_statement", {})) == 0 ? [] : [lookup(rate_based_statement.value, "scope_down_statement", {})]
+              for_each = contains(keys(rate_based_statement.value), "scope_down_statement") && rate_based_statement.value["scope_down_statement"] != null ? [lookup(rate_based_statement.value, "scope_down_statement", {})] : []
               content {
                 # scope down byte_match_statement
                 dynamic "byte_match_statement" {
@@ -6108,8 +6108,8 @@ resource "aws_wafv2_web_acl" "main" {
                     positional_constraint = lookup(byte_match_statement.value, "positional_constraint")
                     search_string         = lookup(byte_match_statement.value, "search_string")
                     text_transformation {
-                      priority = lookup(byte_match_statement.value, "priority")
-                      type     = lookup(byte_match_statement.value, "type")
+                      priority = lookup(byte_match_statement.value["text_transformation"], "priority")
+                      type     = lookup(byte_match_statement.value["text_transformation"], "type")
                     }
                   }
                 }


### PR DESCRIPTION

The current code has a bug:
```
│ Error: Invalid function argument
│
│   on .terraform/modules/waf.waf/main.tf line 6111, in resource "aws_wafv2_web_acl" "main":
│ 6111:                       priority = lookup(byte_match_statement.value, "priority")
│     ├────────────────
│     │ byte_match_statement.value is object with 4 attributes
│
│ Invalid value for "inputMap" parameter: the given object has no attribute "priority".
╵
╷
│ Error: Invalid function argument
│
│   on .terraform/modules/waf.waf/main.tf line 6112, in resource "aws_wafv2_web_acl" "main":
│ 6112:                       type     = lookup(byte_match_statement.value, "type")
│     ├────────────────
│     │ byte_match_statement.value is object with 4 attributes
│
│ Invalid value for "inputMap" parameter: the given object has no attribute "type".
```

This happens because we need to fetch the text_transformation element of the object and not the object itself.

# Description

This fixes that issue.
