### PR TITLE
Fix nested required `text_transformation` and go back to previous behaviour

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2122,8 +2122,8 @@ resource "aws_wafv2_web_acl" "main" {
             positional_constraint = lookup(byte_match_statement.value, "positional_constraint")
             search_string         = lookup(byte_match_statement.value, "search_string")
             text_transformation {
-              priority = lookup(byte_match_statement.value["text_transformation"], "priority")
-              type     = lookup(byte_match_statement.value["text_transformation"], "type")
+              priority = lookup(byte_match_statement.value, "priority")
+              type     = lookup(byte_match_statement.value, "type")
             }
           }
         }
@@ -2457,8 +2457,8 @@ resource "aws_wafv2_web_acl" "main" {
               }
             }
             text_transformation {
-              priority = lookup(sqli_match_statement.value["text_transformation"], "priority")
-              type     = lookup(sqli_match_statement.value["text_transformation"], "type")
+              priority = lookup(sqli_match_statement.value, "priority")
+              type     = lookup(sqli_match_statement.value, "type")
             }
           }
         }
@@ -2518,8 +2518,8 @@ resource "aws_wafv2_web_acl" "main" {
               }
             }
             text_transformation {
-              priority = lookup(xss_match_statement.value["text_transformation"], "priority")
-              type     = lookup(xss_match_statement.value["text_transformation"], "type")
+              priority = lookup(xss_match_statement.value, "priority")
+              type     = lookup(xss_match_statement.value, "type")
             }
           }
         }
@@ -3894,8 +3894,8 @@ resource "aws_wafv2_web_acl" "main" {
                               }
                             }
                             text_transformation {
-                              priority = lookup(sqli_match_statement.value["text_transformation"], "priority")
-                              type     = lookup(sqli_match_statement.value["text_transformation"], "type")
+                              priority = lookup(sqli_match_statement.value, "priority")
+                              type     = lookup(sqli_match_statement.value, "type")
                             }
                           }
                         }
@@ -3972,8 +3972,8 @@ resource "aws_wafv2_web_acl" "main" {
                               }
                             }
                             text_transformation {
-                              priority = lookup(xss_match_statement.value["text_transformation"], "priority")
-                              type     = lookup(xss_match_statement.value["text_transformation"], "type")
+                              priority = lookup(xss_match_statement.value, "priority")
+                              type     = lookup(xss_match_statement.value, "type")
                             }
                           }
                         }
@@ -4454,8 +4454,8 @@ resource "aws_wafv2_web_acl" "main" {
                     }
                   }
                   text_transformation {
-                    priority = lookup(sqli_match_statement.value["text_transformation"], "priority")
-                    type     = lookup(sqli_match_statement.value["text_transformation"], "type")
+                    priority = lookup(sqli_match_statement.value, "priority")
+                    type     = lookup(sqli_match_statement.value, "type")
                   }
                 }
               }
@@ -4532,8 +4532,8 @@ resource "aws_wafv2_web_acl" "main" {
                     }
                   }
                   text_transformation {
-                    priority = lookup(xss_match_statement.value["text_transformation"], "priority")
-                    type     = lookup(xss_match_statement.value["text_transformation"], "type")
+                    priority = lookup(xss_match_statement.value, "priority")
+                    type     = lookup(xss_match_statement.value, "type")
                   }
                 }
               }
@@ -5183,8 +5183,8 @@ resource "aws_wafv2_web_acl" "main" {
                             }
                           }
                           text_transformation {
-                            priority = lookup(sqli_match_statement.value["text_transformation"], "priority")
-                            type     = lookup(sqli_match_statement.value["text_transformation"], "type")
+                            priority = lookup(sqli_match_statement.value, "priority")
+                            type     = lookup(sqli_match_statement.value, "type")
                           }
                         }
                       }
@@ -5261,8 +5261,8 @@ resource "aws_wafv2_web_acl" "main" {
                             }
                           }
                           text_transformation {
-                            priority = lookup(xss_match_statement.value["text_transformation"], "priority")
-                            type     = lookup(xss_match_statement.value["text_transformation"], "type")
+                            priority = lookup(xss_match_statement.value, "priority")
+                            type     = lookup(xss_match_statement.value, "type")
                           }
                         }
                       }
@@ -6133,8 +6133,8 @@ resource "aws_wafv2_web_acl" "main" {
                     positional_constraint = lookup(byte_match_statement.value, "positional_constraint")
                     search_string         = lookup(byte_match_statement.value, "search_string")
                     text_transformation {
-                      priority = lookup(byte_match_statement.value["text_transformation"], "priority")
-                      type     = lookup(byte_match_statement.value["text_transformation"], "type")
+                      priority = lookup(byte_match_statement.value, "priority")
+                      type     = lookup(byte_match_statement.value, "type")
                     }
                   }
                 }
@@ -6211,8 +6211,8 @@ resource "aws_wafv2_web_acl" "main" {
                       }
                     }
                     text_transformation {
-                      priority = lookup(sqli_match_statement.value["text_transformation"], "priority")
-                      type     = lookup(sqli_match_statement.value["text_transformation"], "type")
+                      priority = lookup(sqli_match_statement.value, "priority")
+                      type     = lookup(sqli_match_statement.value, "type")
                     }
                   }
                 }
@@ -6289,8 +6289,8 @@ resource "aws_wafv2_web_acl" "main" {
                       }
                     }
                     text_transformation {
-                      priority = lookup(xss_match_statement.value["text_transformation"], "priority")
-                      type     = lookup(xss_match_statement.value["text_transformation"], "type")
+                      priority = lookup(xss_match_statement.value, "priority")
+                      type     = lookup(xss_match_statement.value, "type")
                     }
                   }
                 }


### PR DESCRIPTION
After
https://github.com/umotif-public/terraform-aws-waf-webaclv2/pull/104, a bug was introduced that would require a nested `text_transformation`. As it wasn't done across the entire module, it has different behaviours on different use-cases.

This fixes that bug and reverts to the previous behaviour.

# Description

Please explain the changes you made here and link to any relevant issues.
