### PR TITLE
Upgrade to AWS provider 5.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     args: ['--allow-missing-credentials']
   - id: trailing-whitespace
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.79.1
+  rev: v1.81.0
   hooks:
   - id: terraform_fmt
   - id: terraform_docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,28 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
-- Add support for xss_match_statement
-- Add missing sqli_match_statement
+- update code for provider > 5.0.0
+- version up
+
+
+<a name="4.6.1"></a>
+## [4.6.1] - 2023-05-19
+
+- Fix invalid input map in byte_match_statement ([#104](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/104))
+
+
+<a name="4.6.0"></a>
+## [4.6.0] - 2023-05-19
+
+- Add support for scope down ip_set_reference_statement in the ratelimit rule ([#103](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/103))
+- Fix 'Invalid value for "inputMap" parameter: the given object has no attribute "type"' ([#102](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/102))
+
+
+<a name="4.5.0"></a>
+## [4.5.0] - 2023-05-17
+
+- Add xss_match_statement support ([#101](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/101))
+- Set 'upper' function for 'match_scope' ([#100](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/100))
 
 
 <a name="4.4.0"></a>
@@ -283,7 +303,10 @@ dependency-type: indirect
 - Initial commit
 
 
-[Unreleased]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/4.4.0...HEAD
+[Unreleased]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/4.6.1...HEAD
+[4.6.1]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/4.6.0...4.6.1
+[4.6.0]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/4.5.0...4.6.0
+[4.5.0]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/4.4.0...4.5.0
 [4.4.0]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/4.3.0...4.4.0
 [4.3.0]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/4.2.0...4.3.0
 [4.2.0]: https://github.com/umotif-public/terraform-aws-waf-webaclv2/compare/4.1.2...4.2.0

--- a/README.md
+++ b/README.md
@@ -429,14 +429,14 @@ Module managed by:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.52.0, < 5.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.52.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.52.0, < 5.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.52.0 |
 
 ## Modules
 

--- a/examples/core/main.tf
+++ b/examples/core/main.tf
@@ -1,15 +1,3 @@
-terraform {
-  required_version = ">= 0.13.7"
-
-  required_providers {
-    aws = ">= 4.44.0"
-  }
-}
-
-provider "aws" {
-  region = "eu-west-1"
-}
-
 #####
 # VPC and subnets
 #####

--- a/examples/core/versions.tf
+++ b/examples/core/versions.tf
@@ -4,7 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.52.0"
+      version = "~> 5.0.0"
     }
   }
+}
+
+provider "aws" {
+  region = "eu-west-1"
 }

--- a/examples/wafv2-and-or-rules/main.tf
+++ b/examples/wafv2-and-or-rules/main.tf
@@ -1,15 +1,3 @@
-terraform {
-  required_version = ">= 0.13.7"
-
-  required_providers {
-    aws = ">= 4.44.0"
-  }
-}
-
-provider "aws" {
-  region = "eu-west-1"
-}
-
 #####
 # IP set resources
 #####

--- a/examples/wafv2-and-or-rules/versions.tf
+++ b/examples/wafv2-and-or-rules/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.52.0"
+      version = "~> 5.0.0"
     }
   }
 }

--- a/examples/wafv2-bytematch-rules/main.tf
+++ b/examples/wafv2-bytematch-rules/main.tf
@@ -1,15 +1,3 @@
-terraform {
-  required_version = ">= 0.13.7"
-
-  required_providers {
-    aws = ">= 4.44.0"
-  }
-}
-
-provider "aws" {
-  region = "eu-west-1"
-}
-
 #####
 # Web Application Firewall configuration
 #####

--- a/examples/wafv2-bytematch-rules/versions.tf
+++ b/examples/wafv2-bytematch-rules/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.52.0"
+      version = "~> 5.0.0"
     }
   }
 }

--- a/examples/wafv2-custom-json-response-managed-rule-group/main.tf
+++ b/examples/wafv2-custom-json-response-managed-rule-group/main.tf
@@ -1,15 +1,3 @@
-terraform {
-  required_version = ">= 0.13.7"
-
-  required_providers {
-    aws = ">= 4.44.0"
-  }
-}
-
-provider "aws" {
-  region = "eu-west-1"
-}
-
 module "waf" {
   source = "../.."
 

--- a/examples/wafv2-custom-json-response-managed-rule-group/versions.tf
+++ b/examples/wafv2-custom-json-response-managed-rule-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.52.0"
+      version = "~> 5.0.0"
     }
   }
 }

--- a/examples/wafv2-custom-response-code/main.tf
+++ b/examples/wafv2-custom-response-code/main.tf
@@ -1,15 +1,3 @@
-terraform {
-  required_version = ">= 0.13.7"
-
-  required_providers {
-    aws = ">= 4.44.0"
-  }
-}
-
-provider "aws" {
-  region = "eu-west-1"
-}
-
 module "waf" {
   source = "../.."
 

--- a/examples/wafv2-custom-response-code/versions.tf
+++ b/examples/wafv2-custom-response-code/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.52.0"
+      version = "~> 5.0.0"
     }
   }
 }

--- a/examples/wafv2-custom-response/main.tf
+++ b/examples/wafv2-custom-response/main.tf
@@ -1,15 +1,3 @@
-terraform {
-  required_version = ">= 0.13.7"
-
-  required_providers {
-    aws = ">= 4.44.0"
-  }
-}
-
-provider "aws" {
-  region = "eu-west-1"
-}
-
 module "waf" {
   source = "../.."
 

--- a/examples/wafv2-custom-response/versions.tf
+++ b/examples/wafv2-custom-response/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.52.0"
+      version = "~> 5.0.0"
     }
   }
 }

--- a/examples/wafv2-geo-rules/main.tf
+++ b/examples/wafv2-geo-rules/main.tf
@@ -1,15 +1,3 @@
-terraform {
-  required_version = ">= 0.13.7"
-
-  required_providers {
-    aws = ">= 4.44.0"
-  }
-}
-
-provider "aws" {
-  region = "eu-west-1"
-}
-
 #####
 # Web Application Firewall configuration
 #####

--- a/examples/wafv2-geo-rules/versions.tf
+++ b/examples/wafv2-geo-rules/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.52.0"
+      version = "~> 5.0.0"
     }
   }
 }

--- a/examples/wafv2-ip-rules/main.tf
+++ b/examples/wafv2-ip-rules/main.tf
@@ -1,15 +1,3 @@
-terraform {
-  required_version = ">= 0.13.7"
-
-  required_providers {
-    aws = ">= 4.44.0"
-  }
-}
-
-provider "aws" {
-  region = "eu-west-1"
-}
-
 #####
 # IP set resources
 #####

--- a/examples/wafv2-ip-rules/versions.tf
+++ b/examples/wafv2-ip-rules/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.52.0"
+      version = "~> 5.0.0"
     }
   }
 }

--- a/examples/wafv2-labelmatch-rules/main.tf
+++ b/examples/wafv2-labelmatch-rules/main.tf
@@ -1,15 +1,3 @@
-terraform {
-  required_version = ">= 0.13.7"
-
-  required_providers {
-    aws = ">= 4.44.0"
-  }
-}
-
-provider "aws" {
-  region = "eu-west-1"
-}
-
 #####
 # Web Application Firewall configuration
 #####

--- a/examples/wafv2-labelmatch-rules/versions.tf
+++ b/examples/wafv2-labelmatch-rules/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.52.0"
+      version = "~> 5.0.0"
     }
   }
 }

--- a/examples/wafv2-logging-configuration/versions.tf
+++ b/examples/wafv2-logging-configuration/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.52.0"
+      version = "~> 5.0.0"
     }
   }
 }

--- a/examples/wafv2-regex-pattern-rules/main.tf
+++ b/examples/wafv2-regex-pattern-rules/main.tf
@@ -1,15 +1,3 @@
-terraform {
-  required_version = ">= 0.13.7"
-
-  required_providers {
-    aws = ">= 4.44.0"
-  }
-}
-
-provider "aws" {
-  region = "eu-west-1"
-}
-
 resource "aws_wafv2_regex_pattern_set" "bad_bots_user_agent" {
   name        = "BadBotsUserAgent"
   description = "Some bots regex pattern set example"

--- a/examples/wafv2-regex-pattern-rules/versions.tf
+++ b/examples/wafv2-regex-pattern-rules/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.52.0"
+      version = "~> 5.0.0"
     }
   }
 }

--- a/examples/wafv2-regexmatch-rules/main.tf
+++ b/examples/wafv2-regexmatch-rules/main.tf
@@ -1,14 +1,3 @@
-terraform {
-  required_version = ">= 0.13.7"
-
-  required_providers {
-    aws = ">= 4.44.0"
-  }
-}
-
-provider "aws" {
-  region = "eu-west-1"
-}
 #####
 # Web Application Firewall configuration
 #####

--- a/examples/wafv2-regexmatch-rules/versions.tf
+++ b/examples/wafv2-regexmatch-rules/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.52.0"
+      version = "~> 5.0.0"
     }
   }
 }

--- a/examples/wafv2-sizeconstraint-rules/main.tf
+++ b/examples/wafv2-sizeconstraint-rules/main.tf
@@ -1,15 +1,3 @@
-terraform {
-  required_version = ">= 0.13.7"
-
-  required_providers {
-    aws = ">= 4.44.0"
-  }
-}
-
-provider "aws" {
-  region = "eu-west-1"
-}
-
 #####
 # Web Application Firewall configuration
 #####

--- a/examples/wafv2-sizeconstraint-rules/versions.tf
+++ b/examples/wafv2-sizeconstraint-rules/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.52.0"
+      version = "~> 5.0.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -113,10 +113,19 @@ resource "aws_wafv2_web_acl" "main" {
           content {
             arn = lookup(rule_group_reference_statement.value, "arn")
 
-            dynamic "excluded_rule" {
-              for_each = length(lookup(rule_group_reference_statement.value, "excluded_rule", {})) == 0 ? [] : toset(lookup(rule_group_reference_statement.value, "excluded_rule"))
+            dynamic "rule_action_override" {
+              for_each = lookup(rule_group_reference_statement.value, "rule_action_overrides", null) == null ? [] : lookup(rule_group_reference_statement.value, "rule_action_overrides")
               content {
-                name = excluded_rule.value
+                name = lookup(rule_action_override.value, "name")
+                dynamic "action_to_use" {
+                  for_each = [lookup(rule_action_override.value, "action_to_use")]
+                  content {
+                    dynamic "count" {
+                      for_each = lookup(action_to_use.value, "count", null) == null ? [] : [lookup(action_to_use.value, "count")]
+                      content {}
+                    }
+                  }
+                }
               }
             }
           }
@@ -6836,13 +6845,6 @@ resource "aws_wafv2_web_acl_logging_configuration" "main" {
         for_each = length(lookup(redacted_fields.value, "single_header", {})) == 0 ? [] : [lookup(redacted_fields.value, "single_header", {})]
         content {
           name = lookup(single_header.value, "name", null)
-        }
-      }
-
-      dynamic "single_query_argument" {
-        for_each = length(lookup(redacted_fields.value, "single_query_argument", {})) == 0 ? [] : [lookup(redacted_fields.value, "single_query_argument", {})]
-        content {
-          name = lookup(single_query_argument.value, "name", null)
         }
       }
     }

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.7"
 
   required_providers {
-    aws = ">= 4.52.0, < 5.0.0"
+    aws = ">= 5.0.0"
   }
 }


### PR DESCRIPTION
# Description

Update code and AWS provider to version 5.0.0.
Tested on AWS provider 5.7.0

Parameters below has been deprecated.
```
dynamic "excluded_rule" {}
```
and

```
dynamic "single_query_argument" {}
```

Relevant for #108 

