### PR TITLE
Add support for `allow`, `block` and `captcha` actions in `rule_action_override`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -152,6 +152,18 @@ resource "aws_wafv2_web_acl" "main" {
                       for_each = lookup(action_to_use.value, "count", null) == null ? [] : [lookup(action_to_use.value, "count")]
                       content {}
                     }
+                    dynamic "allow" {
+                      for_each = lookup(action_to_use.value, "allow", null) == null ? [] : [lookup(action_to_use.value, "allow")]
+                      content {}
+                    }
+                    dynamic "block" {
+                      for_each = lookup(action_to_use.value, "block", null) == null ? [] : [lookup(action_to_use.value, "block")]
+                      content {}
+                    }
+                    dynamic "captcha" {
+                      for_each = lookup(action_to_use.value, "captcha", null) == null ? [] : [lookup(action_to_use.value, "captcha")]
+                      content {}
+                    }
                   }
                 }
               }


### PR DESCRIPTION

Currently only `count` is supported in `rule_action_override`.
As mentioned in multiple issues like #107 or #90 support for other action types is wished.

New actions have been tested and confirmed working.