### PR TITLE
fix: scope_down_statement is optional in rate_based_statement

### DIFF
--- a/examples/wafv2-ip-rules/main.tf
+++ b/examples/wafv2-ip-rules/main.tf
@@ -201,6 +201,21 @@ module "waf" {
         metric_name                = "test-waf-setup-waf-ip-set-block-metrics"
         sampled_requests_enabled   = false
       }
+    },
+    {
+      name     = "ip-rate-limit-wo-scope-down-statement"
+      priority = "7"
+      action   = "count"
+
+      rate_based_statement = {
+        limit              = 1000
+        aggregate_key_type = "IP"
+      }
+
+      visibility_config = {
+        cloudwatch_metrics_enabled = false
+        sampled_requests_enabled   = false
+      }
     }
   ]
 

--- a/main.tf
+++ b/main.tf
@@ -2551,7 +2551,7 @@ resource "aws_wafv2_web_acl" "main" {
             }
 
             dynamic "scope_down_statement" {
-              for_each = contains(keys(rate_based_statement.value), "scope_down_statement") && rate_based_statement.value["scope_down_statement"] != null ? [lookup(rate_based_statement.value, "scope_down_statement", {})] : []
+              for_each = length(lookup(rate_based_statement.value, "scope_down_statement", {})) == 0 ? [] : [lookup(rate_based_statement.value, "scope_down_statement", {})]
               content {
                 # scope down byte_match_statement
                 dynamic "byte_match_statement" {
@@ -2817,7 +2817,7 @@ resource "aws_wafv2_web_acl" "main" {
 
                 # scope down ip_set_reference_statement
                 dynamic "ip_set_reference_statement" {
-                  for_each = contains(keys(scope_down_statement.value), "ip_set_reference_statement") && scope_down_statement.value["ip_set_reference_statement"] != null ? [lookup(scope_down_statement.value, "ip_set_reference_statement", {})] : []
+                  for_each = length(lookup(scope_down_statement.value, "ip_set_reference_statement", {})) == 0 ? [] : [lookup(scope_down_statement.value, "ip_set_reference_statement", {})]
                   content {
                     arn = lookup(ip_set_reference_statement.value, "arn")
                     dynamic "ip_set_forwarded_ip_config" {

--- a/test/waf_webaclv2_ip_rules_test.go
+++ b/test/waf_webaclv2_ip_rules_test.go
@@ -47,12 +47,12 @@ func TestWafWebAclV2IpRules(t *testing.T) {
 	CustomIpSetArn := terraform.Output(t, terraformOptions, "custom_ip_set_arn")
 
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, WebAclName, "test"+uniqueID)
+	assert.Equal(t, "test"+uniqueID, WebAclName)
 	assert.Contains(t, WebAclArn, "arn:aws:wafv2:eu-west-1:")
 	assert.Contains(t, WebAclArn, "regional/webacl/test"+uniqueID)
-	assert.Equal(t, WebAclVisConfigMetricName, "test"+uniqueID+"-waf-setup-waf-main-metrics")
-	assert.Equal(t, WebAclCapacity, "721")
-	assert.Equal(t, WebAclRuleNames, "block-ip-set, allow-custom-ip-set, ip-rate-limit, ip-rate-limit-with-or-scope-down, AWSManagedRulesCommonRuleSet-rule-1")
+	assert.Equal(t, "test"+uniqueID+"-waf-setup-waf-main-metrics", WebAclVisConfigMetricName)
+	assert.Equal(t, "728", WebAclCapacity)
+	assert.Equal(t, "[block-ip-set allow-custom-ip-set allow-custom-ip-set-with-XFF-header ip-rate-limit ip-rate-limit-with-or-scope-down ip-rate-limit-wo-scope-down-statement AWSManagedRulesCommonRuleSet-rule-1]", WebAclRuleNames)
 	assert.Contains(t, BlockIpSetArn, "arn:aws:wafv2:eu-west-1:")
 	assert.Contains(t, BlockIpSetArn, "regional/ipset/test"+uniqueID+"-generated-ips")
 	assert.Contains(t, CustomIpSetArn, "arn:aws:wafv2:eu-west-1:")


### PR DESCRIPTION
# Description

Fixes https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/117
+ adding/fixing test for rate_based_statement without scope_down_statement
