### PR TITLE
fix: repair tests + correct excpected/actual in Equal calls

### DIFF
--- a/examples/wafv2-logging-configuration/variables.tf
+++ b/examples/wafv2-logging-configuration/variables.tf
@@ -1,0 +1,5 @@
+variable "name_prefix" {
+  description = "A prefix used for naming resources."
+  type        = string
+  default     = "example"
+}

--- a/examples/wafv2-sizeconstraint-rules/main.tf
+++ b/examples/wafv2-sizeconstraint-rules/main.tf
@@ -34,7 +34,7 @@ module "waf" {
       managed_rule_group_statement = {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
-        version     = "Version_2.0"
+        version     = "Version_1.6"
       }
     },
     {

--- a/test/waf_webaclv2_and_or_test.go
+++ b/test/waf_webaclv2_and_or_test.go
@@ -43,10 +43,10 @@ func TestWafWebAclV2AndOr(t *testing.T) {
 	WebAclRuleNames := terraform.Output(t, terraformOptions, "web_acl_rule_names")
 
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, WebAclName, "test"+uniqueID)
+	assert.Equal(t, "test"+uniqueID, WebAclName)
 	assert.Contains(t, WebAclArn, "arn:aws:wafv2:eu-west-1:")
 	assert.Contains(t, WebAclArn, "regional/webacl/test"+uniqueID)
-	assert.Equal(t, WebAclVisConfigMetricName, "test"+uniqueID+"-waf-setup-waf-main-metrics")
-	assert.Equal(t, WebAclCapacity, "714")
-	assert.Equal(t, WebAclRuleNames, "block-specific-ip-set-or-body-contains-hotmail, block-specific-uri-path-and-requests-from-nl-gb-and-us, AWSManagedRulesCommonRuleSet-rule-1")
+	assert.Equal(t, "test"+uniqueID+"-waf-setup-waf-main-metrics", WebAclVisConfigMetricName)
+	assert.Equal(t, "760", WebAclCapacity)
+	assert.Equal(t, "[block-specific-ip-set-or-body-contains-hotmail block-specific-uri block-specific-uri-path-and-not-requests-from-nl-gb-and-us block-specific-uri-path-and-requests-from-nl-gb-and-us AWSManagedRulesCommonRuleSet-rule-1]", WebAclRuleNames)
 }

--- a/test/waf_webaclv2_bytematch_test.go
+++ b/test/waf_webaclv2_bytematch_test.go
@@ -43,10 +43,10 @@ func TestWafWebAclV2Bytematch(t *testing.T) {
 	WebAclRuleNames := terraform.Output(t, terraformOptions, "web_acl_rule_names")
 
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, WebAclName, "test"+uniqueID)
+	assert.Equal(t, "test"+uniqueID, WebAclName)
 	assert.Contains(t, WebAclArn, "arn:aws:wafv2:eu-west-1:")
 	assert.Contains(t, WebAclArn, "regional/webacl/test"+uniqueID)
-	assert.Equal(t, WebAclVisConfigMetricName, "test"+uniqueID+"-waf-setup-waf-main-metrics")
-	assert.Equal(t, WebAclCapacity, "736")
-	assert.Equal(t, WebAclRuleNames, "block-all-post-requests, block-if-request-body-contains-hotmail-email, block-single-user, block-specific-uri-path, AWSManagedRulesCommonRuleSet-rule-1")
+	assert.Equal(t, "test"+uniqueID+"-waf-setup-waf-main-metrics", WebAclVisConfigMetricName)
+	assert.Equal(t, "756", WebAclCapacity)
+	assert.Equal(t, "[block-all-post-requests block-cookie block-if-request-body-contains-hotmail-email block-single-user block-specific-uri-path block-unauthorized AWSManagedRulesCommonRuleSet-rule-1]", WebAclRuleNames)
 }

--- a/test/waf_webaclv2_geomatch_test.go
+++ b/test/waf_webaclv2_geomatch_test.go
@@ -43,10 +43,10 @@ func TestWafWebAclV2Geomatch(t *testing.T) {
 	WebAclRuleNames := terraform.Output(t, terraformOptions, "web_acl_rule_names")
 
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, WebAclName, "test"+uniqueID)
+	assert.Equal(t, "test"+uniqueID, WebAclName)
 	assert.Contains(t, WebAclArn, "arn:aws:wafv2:eu-west-1:")
 	assert.Contains(t, WebAclArn, "regional/webacl/test"+uniqueID)
-	assert.Equal(t, WebAclVisConfigMetricName, "test"+uniqueID+"-waf-setup-waf-main-metrics")
-	assert.Equal(t, WebAclCapacity, "701")
-	assert.Equal(t, WebAclRuleNames, "allow-nl-gb-us-traffic-only, AWSManagedRulesCommonRuleSet-rule-1")
+	assert.Equal(t, "test"+uniqueID+"-waf-setup-waf-main-metrics", WebAclVisConfigMetricName)
+	assert.Equal(t, "701", WebAclCapacity)
+	assert.Equal(t, "[allow-nl-gb-us-traffic-only AWSManagedRulesCommonRuleSet-rule-1]", WebAclRuleNames)
 }

--- a/test/waf_webaclv2_label_match_test.go
+++ b/test/waf_webaclv2_label_match_test.go
@@ -43,10 +43,10 @@ func TestWafWebAclV2Labelmatch(t *testing.T) {
 	WebAclRuleNames := terraform.Output(t, terraformOptions, "web_acl_rule_names")
 
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, WebAclName, "test"+uniqueID)
+	assert.Equal(t, "test"+uniqueID, WebAclName)
 	assert.Contains(t, WebAclArn, "arn:aws:wafv2:eu-west-1:")
 	assert.Contains(t, WebAclArn, "regional/webacl/test"+uniqueID)
-	assert.Equal(t, WebAclVisConfigMetricName, "test"+uniqueID+"-waf-setup-waf-main-metrics")
-	assert.Equal(t, WebAclCapacity, "61")
-	assert.Equal(t, WebAclRuleNames, "block-specific-agent, AWSManagedRulesBotControlRuleSet-rule-1")
+	assert.Equal(t, "test"+uniqueID+"-waf-setup-waf-main-metrics", WebAclVisConfigMetricName)
+	assert.Equal(t, "61", WebAclCapacity)
+	assert.Equal(t, "[block-specific-agent AWSManagedRulesBotControlRuleSet-rule-1]", WebAclRuleNames)
 }

--- a/test/waf_webaclv2_logging_config_test.go
+++ b/test/waf_webaclv2_logging_config_test.go
@@ -1,17 +1,29 @@
 package test
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestWafWebAclV2Logging(t *testing.T) {
+	// Random generate a string for naming resources
+	uniqueID := strings.ToLower(random.UniqueId())
+	resourceName := fmt.Sprintf("test%s", uniqueID)
+
 	// retryable errors in terraform testing.
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/wafv2-logging-configuration",
 		Upgrade:      true,
+
+		// Variables to pass using -var-file option
+		Vars: map[string]interface{}{
+			"name_prefix": resourceName,
+		},
 	})
 
 	// At the end of the test, run `terraform destroy` to clean up any resources that were created
@@ -51,39 +63,39 @@ func TestWafWebAclV2Logging(t *testing.T) {
 	S3BucketId := terraform.Output(t, terraformOptions, "logging_s3_bucket_id")
 
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, WebAclName, "test-waf-setup")
+	assert.Equal(t, "test"+uniqueID, WebAclName)
 	assert.Contains(t, WebAclArn, "arn:aws:wafv2:eu-west-1:")
-	assert.Contains(t, WebAclArn, "regional/webacl/test-waf-setup")
-	assert.Equal(t, WebAclVisConfigMetricName, "test-waf-setup-waf-main-metrics")
-	assert.Equal(t, WebAclCapacity, "950")
-	assert.Equal(t, WebAclRuleNames, "AWSManagedRulesCommonRuleSet-rule-1, AWSManagedRulesKnownBadInputsRuleSet-rule-2, AWSManagedRulesPHPRuleSet-rule-3")
+	assert.Contains(t, WebAclArn, "regional/webacl/test"+uniqueID)
+	assert.Equal(t, "test"+uniqueID+"-waf-setup-waf-main-metrics", WebAclVisConfigMetricName)
+	assert.Equal(t, "950", WebAclCapacity)
+	assert.Equal(t, "[AWSManagedRulesCommonRuleSet-rule-1 AWSManagedRulesKnownBadInputsRuleSet-rule-2 AWSManagedRulesPHPRuleSet-rule-3]", WebAclRuleNames)
 
 	assert.Contains(t, WebAclAssociationId, "arn:aws:wafv2:eu-west-1")
-	assert.Contains(t, WebAclAssociationId, "regional/webacl/test-waf-setup")
+	assert.Contains(t, WebAclAssociationId, "regional/webacl/"+resourceName)
 	assert.Contains(t, WebAclAssociationResourceArn, "arn:aws:elasticloadbalancing:eu-west-1")
-	assert.Contains(t, WebAclAssociationResourceArn, "loadbalancer/app/alb-waf-example")
+	assert.Contains(t, WebAclAssociationResourceArn, "loadbalancer/app/"+resourceName+"-alb-waf-example")
 	assert.Contains(t, WebAclAssociationAclArn, "arn:aws:wafv2:eu-west-1:")
-	assert.Contains(t, WebAclAssociationAclArn, "regional/webacl/test-waf-setup")
+	assert.Contains(t, WebAclAssociationAclArn, "regional/webacl/"+resourceName)
 
 	assert.Contains(t, WebAclAssociationAlbListId, "arn:aws:wafv2:eu-west-1")
-	assert.Contains(t, WebAclAssociationAlbListId, "regional/webacl/test-waf-setup")
+	assert.Contains(t, WebAclAssociationAlbListId, "regional/webacl/"+resourceName)
 	assert.Contains(t, WebAclAssociationAlbListResourceArn, "arn:aws:elasticloadbalancing:eu-west-1")
-	assert.Contains(t, WebAclAssociationAlbListResourceArn, "loadbalancer/app/alb-waf-example")
+	assert.Contains(t, WebAclAssociationAlbListResourceArn, "loadbalancer/app/"+resourceName+"-alb-waf-example")
 	assert.Contains(t, WebAclAssociationAlbListAclArn, "arn:aws:wafv2:eu-west-1:")
-	assert.Contains(t, WebAclAssociationAlbListAclArn, "regional/webacl/test-waf-setup")
+	assert.Contains(t, WebAclAssociationAlbListAclArn, "regional/webacl/"+resourceName)
 
 	assert.Contains(t, KinesisStreamArn, "arn:aws:firehose:eu-west-1")
 	assert.Contains(t, KinesisStreamArn, "deliverystream/aws-waf-logs-kinesis-firehose-test-stream")
 
 	assert.Contains(t, IamRoleArn, "arn:aws:iam::")
 	assert.Contains(t, IamRoleArn, "role/firehose-stream-test-role")
-	assert.Equal(t, IamRoleId, "firehose-stream-test-role")
-	assert.Equal(t, IamRoleName, "firehose-stream-test-role")
+	assert.Equal(t, "firehose-stream-test-role", IamRoleId)
+	assert.Equal(t, "firehose-stream-test-role", IamRoleName)
 
-	assert.Equal(t, IamRolePolicyId, "firehose-stream-test-role:firehose-role-custom-policy")
-	assert.Equal(t, IamRolePolicyName, "firehose-role-custom-policy")
-	assert.Equal(t, IamRolePolicyRole, "firehose-stream-test-role")
+	assert.Equal(t, "firehose-stream-test-role:firehose-role-custom-policy", IamRolePolicyId)
+	assert.Equal(t, "firehose-role-custom-policy", IamRolePolicyName)
+	assert.Equal(t, "firehose-stream-test-role", IamRolePolicyRole)
 
-	assert.Equal(t, S3BucketArn, "arn:aws:s3:::aws-waf-firehose-stream-test-bucket")
-	assert.Equal(t, S3BucketId, "aws-waf-firehose-stream-test-bucket")
+	assert.Equal(t, "arn:aws:s3:::test"+uniqueID+"-aws-waf-firehose-stream-test-bucket", S3BucketArn)
+	assert.Equal(t, "test"+uniqueID+"-aws-waf-firehose-stream-test-bucket", S3BucketId)
 }

--- a/test/waf_webaclv2_regex_pattern_test.go
+++ b/test/waf_webaclv2_regex_pattern_test.go
@@ -47,13 +47,13 @@ func TestWafWebAclV2RegexPattern(t *testing.T) {
 	WebAclRuleNames := terraform.Output(t, terraformOptions, "web_acl_rule_names")
 
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, WebAclName, "test"+uniqueID)
+	assert.Equal(t, "test"+uniqueID, WebAclName)
 	assert.Contains(t, WebAclArn, "arn:aws:wafv2:eu-west-1:")
 	assert.Contains(t, WebAclArn, "regional/webacl/test"+uniqueID)
-	assert.Equal(t, WebAclVisConfigMetricName, "test"+uniqueID+"-waf-setup-waf-main-metrics")
-	assert.Equal(t, WebAclCapacity, "35")
+	assert.Equal(t, "test"+uniqueID+"-waf-setup-waf-main-metrics", WebAclVisConfigMetricName)
+	assert.Equal(t, "35", WebAclCapacity)
 	assert.Contains(t, BadBotsRegexArn, "arn:aws:wafv2:eu-west-1:")
 	assert.Contains(t, BadBotsRegexArn, "regional/regexpatternset/BadBotsUserAgent/")
-	assert.Equal(t, BadBotsRegexName, "BadBotsUserAgent")
-	assert.Equal(t, WebAclRuleNames, "MatchRegexRule-1")
+	assert.Equal(t, "BadBotsUserAgent", BadBotsRegexName)
+	assert.Equal(t, "[MatchRegexRule-1]", WebAclRuleNames)
 }

--- a/test/waf_webaclv2_sizeconstraint_test.go
+++ b/test/waf_webaclv2_sizeconstraint_test.go
@@ -43,10 +43,10 @@ func TestWafWebAclV2Sizeconstraint(t *testing.T) {
 	WebAclRuleNames := terraform.Output(t, terraformOptions, "web_acl_rule_names")
 
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, WebAclName, "test"+uniqueID)
+	assert.Equal(t, "test"+uniqueID, WebAclName)
 	assert.Contains(t, WebAclArn, "arn:aws:wafv2:eu-west-1:")
 	assert.Contains(t, WebAclArn, "regional/webacl/test"+uniqueID)
-	assert.Equal(t, WebAclVisConfigMetricName, "test"+uniqueID+"-waf-setup-waf-main-metrics")
-	assert.Equal(t, WebAclCapacity, "737")
-	assert.Equal(t, WebAclRuleNames, "BodySizeConstraint, block-all-post-requests, block-if-request-body-contains-hotmail-email, block-single-user, block-specific-uri-path, AWSManagedRulesCommonRuleSet-rule-1")
+	assert.Equal(t, "test"+uniqueID+"-waf-setup-waf-main-metrics", WebAclVisConfigMetricName)
+	assert.Equal(t, "737", WebAclCapacity)
+	assert.Equal(t, "[BodySizeConstraint block-all-post-requests block-if-request-body-contains-hotmail-email block-single-user block-specific-uri-path AWSManagedRulesCommonRuleSet-rule-1]", WebAclRuleNames)
 }


### PR DESCRIPTION
# Description

- fix tests to be compatible with AWS provider 5.0
- correct `assert.Equal` calls(`expected` is second parameter and `actual` is third) - this was misleading
