### PR TITLE
[Challenge] action added to the managed_rule_group_configs rule_action_overrides.

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ Importantly, make sure that Amazon Kinesis Data Firehose is using a name startin
 - [WAF ACL with and / or rules](https://github.com/umotif-public/terraform-aws-waf-webaclv2/tree/main/examples/wafv2-and-or-rules)
 - [WAF ACL with label match rules](https://github.com/umotif-public/terraform-aws-waf-webaclv2/tree/main/examples/wafv2-labelmatch-rules)
 - [WAF ACL with regex pattern rules](https://github.com/umotif-public/terraform-aws-waf-webaclv2/tree/main/examples/wafv2-regex-pattern-rules)
+- [WAF ACL with targeted bot control challenge action rules](https://github.com/umotif-public/terraform-aws-waf-webaclv2/tree/main/examples/wafv2-targeted-bot-control-managed-rule-group)
 
 
 ## Authors

--- a/examples/wafv2-targeted-bot-control-managed-rule-group/main.tf
+++ b/examples/wafv2-targeted-bot-control-managed-rule-group/main.tf
@@ -1,0 +1,92 @@
+module "waf" {
+  source = "../.."
+
+  name_prefix          = var.name_prefix
+  allow_default_action = true
+
+  create_alb_association = false
+
+  visibility_config = {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "${var.name_prefix}-waf-setup-waf-main-metrics"
+    sampled_requests_enabled   = false
+  }
+
+  rules = [
+    {
+      name     = "AWSManagedRulesBotControlRuleSet-rule"
+      priority = "0"
+
+      # Note: override_action is for managed rule sets only, otherwise would be action
+      override_action = "none"
+
+      visibility_config = {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "AWSManagedRulesBotControlRuleSet-metric"
+        sampled_requests_enabled   = true
+      }
+
+      managed_rule_group_statement = {
+        name        = "AWSManagedRulesBotControlRuleSet"
+        vendor_name = "AWS",
+        managed_rule_group_configs = {
+          aws_managed_rules_bot_control_rule_set = {
+            inspection_level = "TARGETED"
+          }
+        },
+        rule_action_overrides = [
+          {
+            action_to_use = {
+              count = {}
+            }
+
+            name = "SignalNonBrowserUserAgent"
+          },
+          {
+            action_to_use = {
+              count = {}
+            }
+
+            name = "CategoryHttpLibrary"
+          },
+          {
+            action_to_use = {
+              count = {}
+            }
+
+            name = "CategoryMonitoring"
+          },
+          {
+            action_to_use = {
+              challenge = {}
+            }
+
+            name = "TGT_VolumetricIpTokenAbsent"
+          },
+          {
+            action_to_use = {
+              captcha = {}
+            }
+
+            name = "TGT_VolumetricSession"
+          },
+          {
+            action_to_use = {
+              captcha = {}
+            }
+
+            name = "TGT_TokenReuseIp"
+          },
+          {
+            action_to_use = {
+              captcha = {}
+            }
+
+            name = "TGT_SignalBrowserInconsistency"
+          },
+        ]
+      }
+    },
+
+  ]
+}

--- a/examples/wafv2-targeted-bot-control-managed-rule-group/variables.tf
+++ b/examples/wafv2-targeted-bot-control-managed-rule-group/variables.tf
@@ -1,0 +1,5 @@
+variable "name_prefix" {
+  description = "A prefix used for naming resources."
+  type        = string
+  default     = "example"
+}

--- a/examples/wafv2-targeted-bot-control-managed-rule-group/versions.tf
+++ b/examples/wafv2-targeted-bot-control-managed-rule-group/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -173,6 +173,10 @@ resource "aws_wafv2_web_acl" "main" {
                       for_each = lookup(action_to_use.value, "captcha", null) == null ? [] : [lookup(action_to_use.value, "captcha")]
                       content {}
                     }
+                    dynamic "challenge" {
+                      for_each = lookup(action_to_use.value, "challenge", null) == null ? [] : [lookup(action_to_use.value, "challenge")]
+                      content {}
+                    }
                   }
                 }
               }


### PR DESCRIPTION
# Description

Added the `challenge` action to the managed rule groups action overrides. 

Also, added a new example directory to show of its usage along with the targeted bot control inspection setting, which took some deciphering of the `inspection_level` in the [main.tf](./../blob/main/main.tf) file to figure out for myself. Thought I make it easier for the next person. 
