### PR TITLE
add: missing NOT regex_pattern_set_reference_statement dynamic blocks

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5238,6 +5238,88 @@ resource "aws_wafv2_web_acl" "main" {
                   }
                 }
 
+                # AND size_constraint_statement
+                dynamic "size_constraint_statement" {
+                  for_each = length(lookup(statement.value, "size_constraint_statement", {})) == 0 ? [] : [lookup(statement.value, "size_constraint_statement", {})]
+                  content {
+                    dynamic "field_to_match" {
+                      for_each = length(lookup(size_constraint_statement.value, "field_to_match", {})) == 0 ? [] : [lookup(size_constraint_statement.value, "field_to_match", {})]
+                      content {
+                        dynamic "cookies" {
+                          for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
+                          content {
+                            match_scope       = upper(lookup(cookies.value, "match_scope"))
+                            oversize_handling = lookup(cookies.value, "oversize_handling")
+                            dynamic "match_pattern" {
+                              for_each = [lookup(cookies.value, "match_pattern")]
+                              content {
+                                dynamic "all" {
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                  content {}
+                                }
+                                included_cookies = length(lookup(match_pattern.value, "included_cookies", [])) != 0 ? lookup(match_pattern.value, "included_cookies") : []
+                                excluded_cookies = length(lookup(match_pattern.value, "excluded_cookies", [])) != 0 ? lookup(match_pattern.value, "excluded_cookies") : []
+                              }
+                            }
+                          }
+                        }
+                        dynamic "uri_path" {
+                          for_each = length(lookup(field_to_match.value, "uri_path", {})) == 0 ? [] : [lookup(field_to_match.value, "uri_path")]
+                          content {}
+                        }
+                        dynamic "all_query_arguments" {
+                          for_each = length(lookup(field_to_match.value, "all_query_arguments", {})) == 0 ? [] : [lookup(field_to_match.value, "all_query_arguments")]
+                          content {}
+                        }
+                        dynamic "body" {
+                          for_each = length(lookup(field_to_match.value, "body", {})) == 0 ? [] : [lookup(field_to_match.value, "body")]
+                          content {
+                            oversize_handling = upper(lookup(body.value, "oversize_handling"))
+                          }
+                        }
+                        dynamic "method" {
+                          for_each = length(lookup(field_to_match.value, "method", {})) == 0 ? [] : [lookup(field_to_match.value, "method")]
+                          content {}
+                        }
+                        dynamic "query_string" {
+                          for_each = length(lookup(field_to_match.value, "query_string", {})) == 0 ? [] : [lookup(field_to_match.value, "query_string")]
+                          content {}
+                        }
+                        dynamic "single_header" {
+                          for_each = length(lookup(field_to_match.value, "single_header", {})) == 0 ? [] : [lookup(field_to_match.value, "single_header")]
+                          content {
+                            name = lower(lookup(single_header.value, "name"))
+                          }
+                        }
+                        dynamic "headers" {
+                          for_each = length(lookup(field_to_match.value, "headers", {})) == 0 ? [] : [lookup(field_to_match.value, "headers")]
+                          content {
+                            match_scope = upper(lookup(headers.value, "match_scope"))
+                            dynamic "match_pattern" {
+                              for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
+                              content {
+                                dynamic "all" {
+                                  for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                  content {}
+                                }
+                                included_headers = lookup(match_pattern.value, "included_headers", null)
+                                excluded_headers = lookup(match_pattern.value, "excluded_headers", null)
+                              }
+                            }
+                            oversize_handling = upper(lookup(headers.value, "oversize_handling"))
+                          }
+                        }
+                      }
+                    }
+                    comparison_operator = lookup(size_constraint_statement.value, "comparison_operator")
+                    size                = lookup(size_constraint_statement.value, "size")
+                    text_transformation {
+                      priority = lookup(size_constraint_statement.value, "priority")
+                      type     = lookup(size_constraint_statement.value, "type")
+                    }
+                  }
+                }
+
                 ### AND not_statement
                 dynamic "not_statement" {
                   for_each = length(lookup(statement.value, "not_statement", {})) == 0 ? [] : [lookup(statement.value, "not_statement", {})]

--- a/main.tf
+++ b/main.tf
@@ -2550,6 +2550,50 @@ resource "aws_wafv2_web_acl" "main" {
               }
             }
 
+            dynamic "custom_key" {
+              for_each = length(lookup(rate_based_statement.value, "custom_key", {})) == 0 ? [] : [lookup(rate_based_statement.value, "custom_key", {})]
+              content {
+                dynamic "header" {
+                  for_each = length(lookup(custom_key.value, "header", {})) == 0 ? [] : [lookup(custom_key.value, "header", {})]
+                  content {
+                    name = lookup(header.value, "name")
+                    text_transformation {
+                      priority = lookup(header.value, "priority")
+                      type     = lookup(header.value, "type")
+                    }
+                  }
+                }
+                dynamic "query_argument" {
+                  for_each = length(lookup(custom_key.value, "query_argument", {})) == 0 ? [] : [lookup(custom_key.value, "query_argument", {})]
+                  content {
+                    name = lookup(query_argument.value, "name")
+                    text_transformation {
+                      priority = lookup(query_argument.value, "priority")
+                      type     = lookup(query_argument.value, "type")
+                    }
+                  }
+                }
+                dynamic "uri_path" {
+                  for_each = length(lookup(custom_key.value, "uri_path", {})) == 0 ? [] : [lookup(custom_key.value, "uri_path", {})]
+                  content {
+                    text_transformation {
+                      priority = lookup(uri_path.value, "priority")
+                      type     = lookup(uri_path.value, "type")
+                    }
+                  }
+                }
+                dynamic "query_string" {
+                  for_each = length(lookup(custom_key.value, "query_string", {})) == 0 ? [] : [lookup(custom_key.value, "query_string", {})]
+                  content {
+                    text_transformation {
+                      priority = lookup(query_string.value, "priority")
+                      type     = lookup(query_string.value, "type")
+                    }
+                  }
+                }
+              }
+            }
+
             dynamic "scope_down_statement" {
               for_each = length(lookup(rate_based_statement.value, "scope_down_statement", {})) == 0 ? [] : [lookup(rate_based_statement.value, "scope_down_statement", {})]
               content {

--- a/main.tf
+++ b/main.tf
@@ -3034,6 +3034,84 @@ resource "aws_wafv2_web_acl" "main" {
                           scope = lookup(label_match_statement.value, "scope")
                         }
                       }
+                      # Scope down NOT regex_pattern_set_reference_statement
+                      dynamic "regex_pattern_set_reference_statement" {
+                        for_each = length(lookup(not_statement.value, "regex_pattern_set_reference_statement", {})) == 0 ? [] : [lookup(not_statement.value, "regex_pattern_set_reference_statement", {})]
+                        content {
+                          arn = lookup(regex_pattern_set_reference_statement.value, "arn")
+                          dynamic "field_to_match" {
+                            for_each = length(lookup(regex_pattern_set_reference_statement.value, "field_to_match", {})) == 0 ? [] : [lookup(regex_pattern_set_reference_statement.value, "field_to_match", {})]
+                            content {
+                              dynamic "cookies" {
+                                for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
+                                content {
+                                  match_scope       = upper(lookup(cookies.value, "match_scope"))
+                                  oversize_handling = lookup(cookies.value, "oversize_handling")
+                                  dynamic "match_pattern" {
+                                    for_each = [lookup(cookies.value, "match_pattern")]
+                                    content {
+                                      dynamic "all" {
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                        content {}
+                                      }
+                                      included_cookies = length(lookup(match_pattern.value, "included_cookies", [])) != 0 ? lookup(match_pattern.value, "included_cookies") : []
+                                      excluded_cookies = length(lookup(match_pattern.value, "excluded_cookies", [])) != 0 ? lookup(match_pattern.value, "excluded_cookies") : []
+                                    }
+                                  }
+                                }
+                              }
+                              dynamic "uri_path" {
+                                for_each = length(lookup(field_to_match.value, "uri_path", {})) == 0 ? [] : [lookup(field_to_match.value, "uri_path")]
+                                content {}
+                              }
+                              dynamic "all_query_arguments" {
+                                for_each = length(lookup(field_to_match.value, "all_query_arguments", {})) == 0 ? [] : [lookup(field_to_match.value, "all_query_arguments")]
+                                content {}
+                              }
+                              dynamic "body" {
+                                for_each = length(lookup(field_to_match.value, "body", {})) == 0 ? [] : [lookup(field_to_match.value, "body")]
+                                content {}
+                              }
+                              dynamic "method" {
+                                for_each = length(lookup(field_to_match.value, "method", {})) == 0 ? [] : [lookup(field_to_match.value, "method")]
+                                content {}
+                              }
+                              dynamic "query_string" {
+                                for_each = length(lookup(field_to_match.value, "query_string", {})) == 0 ? [] : [lookup(field_to_match.value, "query_string")]
+                                content {}
+                              }
+                              dynamic "single_header" {
+                                for_each = length(lookup(field_to_match.value, "single_header", {})) == 0 ? [] : [lookup(field_to_match.value, "single_header")]
+                                content {
+                                  name = lower(lookup(single_header.value, "name"))
+                                }
+                              }
+                              dynamic "headers" {
+                                for_each = length(lookup(field_to_match.value, "headers", {})) == 0 ? [] : [lookup(field_to_match.value, "headers")]
+                                content {
+                                  match_scope = upper(lookup(headers.value, "match_scope"))
+                                  dynamic "match_pattern" {
+                                    for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
+                                    content {
+                                      dynamic "all" {
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                        content {}
+                                      }
+                                      included_headers = lookup(match_pattern.value, "included_headers", null)
+                                      excluded_headers = lookup(match_pattern.value, "excluded_headers", null)
+                                    }
+                                  }
+                                  oversize_handling = upper(lookup(headers.value, "oversize_handling"))
+                                }
+                              }
+                            }
+                          }
+                          text_transformation {
+                            priority = lookup(regex_pattern_set_reference_statement.value, "priority")
+                            type     = lookup(regex_pattern_set_reference_statement.value, "type")
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -3445,6 +3523,84 @@ resource "aws_wafv2_web_acl" "main" {
                                 content {
                                   key   = lookup(label_match_statement.value, "key")
                                   scope = lookup(label_match_statement.value, "scope")
+                                }
+                              }
+                              # Scope down NOT regex_pattern_set_reference_statement
+                              dynamic "regex_pattern_set_reference_statement" {
+                                for_each = length(lookup(not_statement.value, "regex_pattern_set_reference_statement", {})) == 0 ? [] : [lookup(not_statement.value, "regex_pattern_set_reference_statement", {})]
+                                content {
+                                  arn = lookup(regex_pattern_set_reference_statement.value, "arn")
+                                  dynamic "field_to_match" {
+                                    for_each = length(lookup(regex_pattern_set_reference_statement.value, "field_to_match", {})) == 0 ? [] : [lookup(regex_pattern_set_reference_statement.value, "field_to_match", {})]
+                                    content {
+                                      dynamic "cookies" {
+                                        for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
+                                        content {
+                                          match_scope       = upper(lookup(cookies.value, "match_scope"))
+                                          oversize_handling = lookup(cookies.value, "oversize_handling")
+                                          dynamic "match_pattern" {
+                                            for_each = [lookup(cookies.value, "match_pattern")]
+                                            content {
+                                              dynamic "all" {
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                                content {}
+                                              }
+                                              included_cookies = length(lookup(match_pattern.value, "included_cookies", [])) != 0 ? lookup(match_pattern.value, "included_cookies") : []
+                                              excluded_cookies = length(lookup(match_pattern.value, "excluded_cookies", [])) != 0 ? lookup(match_pattern.value, "excluded_cookies") : []
+                                            }
+                                          }
+                                        }
+                                      }
+                                      dynamic "uri_path" {
+                                        for_each = length(lookup(field_to_match.value, "uri_path", {})) == 0 ? [] : [lookup(field_to_match.value, "uri_path")]
+                                        content {}
+                                      }
+                                      dynamic "all_query_arguments" {
+                                        for_each = length(lookup(field_to_match.value, "all_query_arguments", {})) == 0 ? [] : [lookup(field_to_match.value, "all_query_arguments")]
+                                        content {}
+                                      }
+                                      dynamic "body" {
+                                        for_each = length(lookup(field_to_match.value, "body", {})) == 0 ? [] : [lookup(field_to_match.value, "body")]
+                                        content {}
+                                      }
+                                      dynamic "method" {
+                                        for_each = length(lookup(field_to_match.value, "method", {})) == 0 ? [] : [lookup(field_to_match.value, "method")]
+                                        content {}
+                                      }
+                                      dynamic "query_string" {
+                                        for_each = length(lookup(field_to_match.value, "query_string", {})) == 0 ? [] : [lookup(field_to_match.value, "query_string")]
+                                        content {}
+                                      }
+                                      dynamic "single_header" {
+                                        for_each = length(lookup(field_to_match.value, "single_header", {})) == 0 ? [] : [lookup(field_to_match.value, "single_header")]
+                                        content {
+                                          name = lower(lookup(single_header.value, "name"))
+                                        }
+                                      }
+                                      dynamic "headers" {
+                                        for_each = length(lookup(field_to_match.value, "headers", {})) == 0 ? [] : [lookup(field_to_match.value, "headers")]
+                                        content {
+                                          match_scope = upper(lookup(headers.value, "match_scope"))
+                                          dynamic "match_pattern" {
+                                            for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
+                                            content {
+                                              dynamic "all" {
+                                                for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                                content {}
+                                              }
+                                              included_headers = lookup(match_pattern.value, "included_headers", null)
+                                              excluded_headers = lookup(match_pattern.value, "excluded_headers", null)
+                                            }
+                                          }
+                                          oversize_handling = upper(lookup(headers.value, "oversize_handling"))
+                                        }
+                                      }
+                                    }
+                                  }
+                                  text_transformation {
+                                    priority = lookup(regex_pattern_set_reference_statement.value, "priority")
+                                    type     = lookup(regex_pattern_set_reference_statement.value, "type")
+                                  }
                                 }
                               }
                             }

--- a/main.tf
+++ b/main.tf
@@ -5680,6 +5680,88 @@ resource "aws_wafv2_web_acl" "main" {
                         }
                       }
 
+                      # AND not_statement size_constraint_statement
+                      dynamic "size_constraint_statement" {
+                        for_each = length(lookup(not_statement.value, "size_constraint_statement", {})) == 0 ? [] : [lookup(not_statement.value, "size_constraint_statement", {})]
+                        content {
+                          dynamic "field_to_match" {
+                            for_each = length(lookup(size_constraint_statement.value, "field_to_match", {})) == 0 ? [] : [lookup(size_constraint_statement.value, "field_to_match", {})]
+                            content {
+                              dynamic "cookies" {
+                                for_each = length(lookup(field_to_match.value, "cookies", {})) == 0 ? [] : [lookup(field_to_match.value, "cookies")]
+                                content {
+                                  match_scope       = upper(lookup(cookies.value, "match_scope"))
+                                  oversize_handling = lookup(cookies.value, "oversize_handling")
+                                  dynamic "match_pattern" {
+                                    for_each = [lookup(cookies.value, "match_pattern")]
+                                    content {
+                                      dynamic "all" {
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                        content {}
+                                      }
+                                      included_cookies = length(lookup(match_pattern.value, "included_cookies", [])) != 0 ? lookup(match_pattern.value, "included_cookies") : []
+                                      excluded_cookies = length(lookup(match_pattern.value, "excluded_cookies", [])) != 0 ? lookup(match_pattern.value, "excluded_cookies") : []
+                                    }
+                                  }
+                                }
+                              }
+                              dynamic "uri_path" {
+                                for_each = length(lookup(field_to_match.value, "uri_path", {})) == 0 ? [] : [lookup(field_to_match.value, "uri_path")]
+                                content {}
+                              }
+                              dynamic "all_query_arguments" {
+                                for_each = length(lookup(field_to_match.value, "all_query_arguments", {})) == 0 ? [] : [lookup(field_to_match.value, "all_query_arguments")]
+                                content {}
+                              }
+                              dynamic "body" {
+                                for_each = length(lookup(field_to_match.value, "body", {})) == 0 ? [] : [lookup(field_to_match.value, "body")]
+                                content {
+                                  oversize_handling = upper(lookup(body.value, "oversize_handling"))
+                                }
+                              }
+                              dynamic "method" {
+                                for_each = length(lookup(field_to_match.value, "method", {})) == 0 ? [] : [lookup(field_to_match.value, "method")]
+                                content {}
+                              }
+                              dynamic "query_string" {
+                                for_each = length(lookup(field_to_match.value, "query_string", {})) == 0 ? [] : [lookup(field_to_match.value, "query_string")]
+                                content {}
+                              }
+                              dynamic "single_header" {
+                                for_each = length(lookup(field_to_match.value, "single_header", {})) == 0 ? [] : [lookup(field_to_match.value, "single_header")]
+                                content {
+                                  name = lower(lookup(single_header.value, "name"))
+                                }
+                              }
+                              dynamic "headers" {
+                                for_each = length(lookup(field_to_match.value, "headers", {})) == 0 ? [] : [lookup(field_to_match.value, "headers")]
+                                content {
+                                  match_scope = upper(lookup(headers.value, "match_scope"))
+                                  dynamic "match_pattern" {
+                                    for_each = length(lookup(headers.value, "match_pattern", {})) == 0 ? [] : [lookup(headers.value, "match_pattern", {})]
+                                    content {
+                                      dynamic "all" {
+                                        for_each = contains(keys(match_pattern.value), "all") ? [lookup(match_pattern.value, "all")] : []
+                                        content {}
+                                      }
+                                      included_headers = lookup(match_pattern.value, "included_headers", null)
+                                      excluded_headers = lookup(match_pattern.value, "excluded_headers", null)
+                                    }
+                                  }
+                                  oversize_handling = upper(lookup(headers.value, "oversize_handling"))
+                                }
+                              }
+                            }
+                          }
+                          comparison_operator = lookup(size_constraint_statement.value, "comparison_operator")
+                          size                = lookup(size_constraint_statement.value, "size")
+                          text_transformation {
+                            priority = lookup(size_constraint_statement.value, "priority")
+                            type     = lookup(size_constraint_statement.value, "type")
+                          }
+                        }
+                      }
+
                       # AND not_statement regex_pattern_set_reference_statement
                       dynamic "regex_pattern_set_reference_statement" {
                         for_each = length(lookup(not_statement.value, "regex_pattern_set_reference_statement", {})) == 0 ? [] : [lookup(not_statement.value, "regex_pattern_set_reference_statement", {})]


### PR DESCRIPTION
# Description

When using `and_statement` within `rate_based_statement` we cannot add negated `regex_pattern_set_reference_statement` cause the corresponding dynamic block is missing.

## Example:
```
  rules = [
    {
      name     = "example_rate_limit"
      priority = "3"

      action = "count"

      visibility_config = {
        cloudwatch_metrics_enabled = true
        metric_name                = "example_rate_limit"
        sampled_requests_enabled   = true
      }

      rate_based_statement = {
        limit              = 3000
        aggregate_key_type = "IP"
        scope_down_statement = {
          and_statement = {
            statements = [
              {
                byte_match_statement = {
                  field_to_match = {
                    single_header = {
                      name = "Host"
                    }
                  }
                  positional_constraint = "STARTS_WITH"
                  search_string         = "example."
                  priority              = 0
                  type                  = "NONE"
                }
              },
              {
                not_statement = {
                  regex_pattern_set_reference_statement = {
                    arn = aws_wafv2_regex_pattern_set.example.arn
                    field_to_match = {
                      uri_path = "{}"
                    }
                    priority = 0
                    type     = "LOWERCASE"
                  }
                }
              }
            ]
          }
        }
      }
    }
  ]
```
produces:
```
      + rule {
          + name     = "example_rate_limit"
          + priority = 3

          + action {
              + count {
                }
            }

          + statement {
              + rate_based_statement {
                  + aggregate_key_type = "IP"
                  + limit              = 3000

                  + scope_down_statement {
                      + and_statement {
                          + statement {
                              + byte_match_statement {
                                  + positional_constraint = "STARTS_WITH"
                                  + search_string         = "example."

                                  + field_to_match {
                                    }

                                  + text_transformation {
                                      + priority = 0
                                      + type     = "NONE"
                                    }
                                }
                            }
                          + statement {
                              + not_statement {
                                  + statement {
                                    }
                                }
                            }
                        }
                    }
                }
            }
```
Also added: 
* `custom_key` block (was missing)
* `size_constraint_statement` block in `and_statement`
* NOT `size_constraint_statement` block in `and_statement`