### PR TITLE
Updates to ip_set_forward_ip_config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -366,11 +366,11 @@ resource "aws_wafv2_web_acl" "main" {
                         content {
                           arn = lookup(ip_set_reference_statement.value, "arn")
                           dynamic "ip_set_forwarded_ip_config" {
-                            for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                            for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                             content {
-                              fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                              header_name       = lookup(forwarded_ip_config.value, "header_name")
-                              position          = lookup(forwarded_ip_config.value, "position")
+                              fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                              header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                              position          = lookup(ip_set_forwarded_ip_config.value, "position")
                             }
                           }
                         }
@@ -819,11 +819,11 @@ resource "aws_wafv2_web_acl" "main" {
                           content {
                             arn = lookup(ip_set_reference_statement.value, "arn")
                             dynamic "ip_set_forwarded_ip_config" {
-                              for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                              for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                               content {
-                                fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                                header_name       = lookup(forwarded_ip_config.value, "header_name")
-                                position          = lookup(forwarded_ip_config.value, "position")
+                                fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                                header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                                position          = lookup(ip_set_forwarded_ip_config.value, "position")
                               }
                             }
                           }
@@ -919,11 +919,11 @@ resource "aws_wafv2_web_acl" "main" {
                                 content {
                                   arn = lookup(ip_set_reference_statement.value, "arn")
                                   dynamic "ip_set_forwarded_ip_config" {
-                                    for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                                    for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
                                     content {
-                                      fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                                      header_name       = lookup(forwarded_ip_config.value, "header_name")
-                                      position          = lookup(forwarded_ip_config.value, "position")
+                                      fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                                      header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                                      position          = lookup(ip_set_forwarded_ip_config.value, "position")
                                     }
                                   }
                                 }
@@ -1382,11 +1382,11 @@ resource "aws_wafv2_web_acl" "main" {
                                   content {
                                     arn = lookup(ip_set_reference_statement.value, "arn")
                                     dynamic "ip_set_forwarded_ip_config" {
-                                      for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                                      for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                                       content {
-                                        fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                                        header_name       = lookup(forwarded_ip_config.value, "header_name")
-                                        position          = lookup(forwarded_ip_config.value, "position")
+                                        fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                                        header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                                        position          = lookup(ip_set_forwarded_ip_config.value, "position")
                                       }
                                     }
                                   }
@@ -1677,11 +1677,11 @@ resource "aws_wafv2_web_acl" "main" {
                           content {
                             arn = lookup(ip_set_reference_statement.value, "arn")
                             dynamic "ip_set_forwarded_ip_config" {
-                              for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                              for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                               content {
-                                fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                                header_name       = lookup(forwarded_ip_config.value, "header_name")
-                                position          = lookup(forwarded_ip_config.value, "position")
+                                fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                                header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                                position          = lookup(ip_set_forwarded_ip_config.value, "position")
                               }
                             }
                           }
@@ -1951,11 +1951,11 @@ resource "aws_wafv2_web_acl" "main" {
                                 content {
                                   arn = lookup(ip_set_reference_statement.value, "arn")
                                   dynamic "ip_set_forwarded_ip_config" {
-                                    for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                                    for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                                     content {
-                                      fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                                      header_name       = lookup(forwarded_ip_config.value, "header_name")
-                                      position          = lookup(forwarded_ip_config.value, "position")
+                                      fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                                      header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                                      position          = lookup(ip_set_forwarded_ip_config.value, "position")
                                     }
                                   }
                                 }
@@ -2821,11 +2821,11 @@ resource "aws_wafv2_web_acl" "main" {
                   content {
                     arn = lookup(ip_set_reference_statement.value, "arn")
                     dynamic "ip_set_forwarded_ip_config" {
-                      for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                      for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                       content {
-                        fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                        header_name       = lookup(forwarded_ip_config.value, "header_name")
-                        position          = lookup(forwarded_ip_config.value, "position")
+                        fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                        header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                        position          = lookup(ip_set_forwarded_ip_config.value, "position")
                       }
                     }
                   }
@@ -2842,11 +2842,11 @@ resource "aws_wafv2_web_acl" "main" {
                         content {
                           arn = lookup(ip_set_reference_statement.value, "arn")
                           dynamic "ip_set_forwarded_ip_config" {
-                            for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                            for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                             content {
-                              fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                              header_name       = lookup(forwarded_ip_config.value, "header_name")
-                              position          = lookup(forwarded_ip_config.value, "position")
+                              fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                              header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                              position          = lookup(ip_set_forwarded_ip_config.value, "position")
                             }
                           }
                         }
@@ -3226,11 +3226,11 @@ resource "aws_wafv2_web_acl" "main" {
                           content {
                             arn = lookup(ip_set_reference_statement.value, "arn")
                             dynamic "ip_set_forwarded_ip_config" {
-                              for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                              for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                               content {
-                                fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                                header_name       = lookup(forwarded_ip_config.value, "header_name")
-                                position          = lookup(forwarded_ip_config.value, "position")
+                                fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                                header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                                position          = lookup(ip_set_forwarded_ip_config.value, "position")
                               }
                             }
                           }
@@ -3256,11 +3256,11 @@ resource "aws_wafv2_web_acl" "main" {
                                 content {
                                   arn = lookup(ip_set_reference_statement.value, "arn")
                                   dynamic "ip_set_forwarded_ip_config" {
-                                    for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                                    for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                                     content {
-                                      fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                                      header_name       = lookup(forwarded_ip_config.value, "header_name")
-                                      position          = lookup(forwarded_ip_config.value, "position")
+                                      fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                                      header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                                      position          = lookup(ip_set_forwarded_ip_config.value, "position")
                                     }
                                   }
                                 }
@@ -3640,7 +3640,7 @@ resource "aws_wafv2_web_acl" "main" {
                                   content {
                                     arn = lookup(ip_set_reference_statement.value, "arn")
                                     dynamic "ip_set_forwarded_ip_config" {
-                                      for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                                      for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                                       content {
                                         fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
                                         header_name       = lookup(forwarded_ip_config.value, "header_name")
@@ -4090,11 +4090,11 @@ resource "aws_wafv2_web_acl" "main" {
                           content {
                             arn = lookup(ip_set_reference_statement.value, "arn")
                             dynamic "ip_set_forwarded_ip_config" {
-                              for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                              for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                               content {
-                                fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                                header_name       = lookup(forwarded_ip_config.value, "header_name")
-                                position          = lookup(forwarded_ip_config.value, "position")
+                                fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                                header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                                position          = lookup(ip_set_forwarded_ip_config.value, "position")
                               }
                             }
                           }
@@ -4650,11 +4650,11 @@ resource "aws_wafv2_web_acl" "main" {
                 content {
                   arn = lookup(ip_set_reference_statement.value, "arn")
                   dynamic "ip_set_forwarded_ip_config" {
-                    for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                    for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                     content {
-                      fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                      header_name       = lookup(forwarded_ip_config.value, "header_name")
-                      position          = lookup(forwarded_ip_config.value, "position")
+                      fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                      header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                      position          = lookup(ip_set_forwarded_ip_config.value, "position")
                     }
                   }
                 }
@@ -4940,11 +4940,11 @@ resource "aws_wafv2_web_acl" "main" {
                   content {
                     arn = lookup(ip_set_reference_statement.value, "arn")
                     dynamic "ip_set_forwarded_ip_config" {
-                      for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                      for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                       content {
-                        fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                        header_name       = lookup(forwarded_ip_config.value, "header_name")
-                        position          = lookup(forwarded_ip_config.value, "position")
+                        fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                        header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                        position          = lookup(ip_set_forwarded_ip_config.value, "position")
                       }
                     }
                   }
@@ -5669,11 +5669,11 @@ resource "aws_wafv2_web_acl" "main" {
                           content {
                             arn = lookup(ip_set_reference_statement.value, "arn")
                             dynamic "ip_set_forwarded_ip_config" {
-                              for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                              for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                               content {
-                                fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                                header_name       = lookup(forwarded_ip_config.value, "header_name")
-                                position          = lookup(forwarded_ip_config.value, "position")
+                                fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                                header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                                position          = lookup(ip_set_forwarded_ip_config.value, "position")
                               }
                             }
                           }
@@ -5952,11 +5952,11 @@ resource "aws_wafv2_web_acl" "main" {
                                 content {
                                   arn = lookup(ip_set_reference_statement.value, "arn")
                                   dynamic "ip_set_forwarded_ip_config" {
-                                    for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                                    for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                                     content {
-                                      fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                                      header_name       = lookup(forwarded_ip_config.value, "header_name")
-                                      position          = lookup(forwarded_ip_config.value, "position")
+                                      fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                                      header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                                      position          = lookup(ip_set_forwarded_ip_config.value, "position")
                                     }
                                   }
                                 }
@@ -6407,11 +6407,11 @@ resource "aws_wafv2_web_acl" "main" {
                   content {
                     arn = lookup(ip_set_reference_statement.value, "arn")
                     dynamic "ip_set_forwarded_ip_config" {
-                      for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                      for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                       content {
-                        fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                        header_name       = lookup(forwarded_ip_config.value, "header_name")
-                        position          = lookup(forwarded_ip_config.value, "position")
+                        fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                        header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                        position          = lookup(ip_set_forwarded_ip_config.value, "position")
                       }
                     }
                   }
@@ -6690,11 +6690,11 @@ resource "aws_wafv2_web_acl" "main" {
                         content {
                           arn = lookup(ip_set_reference_statement.value, "arn")
                           dynamic "ip_set_forwarded_ip_config" {
-                            for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                            for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                             content {
-                              fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                              header_name       = lookup(forwarded_ip_config.value, "header_name")
-                              position          = lookup(forwarded_ip_config.value, "position")
+                              fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                              header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                              position          = lookup(ip_set_forwarded_ip_config.value, "position")
                             }
                           }
                         }

--- a/main.tf
+++ b/main.tf
@@ -5379,11 +5379,11 @@ resource "aws_wafv2_web_acl" "main" {
                         content {
                           arn = lookup(ip_set_reference_statement.value, "arn")
                           dynamic "ip_set_forwarded_ip_config" {
-                            for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                            for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                             content {
-                              fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                              header_name       = lookup(forwarded_ip_config.value, "header_name")
-                              position          = lookup(forwarded_ip_config.value, "position")
+                              fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                              header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                              position          = lookup(ip_set_forwarded_ip_config.value, "position")
                             }
                           }
                         }


### PR DESCRIPTION
# Description
Currently with all ip_set_reference statements to set the ip_set_forwarded_ip_config the following dynamic statement is used in all scope down and nested and/or/not statements.

`                            dynamic "ip_set_forwarded_ip_config" {
                              for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
                              content {
                                fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
                                header_name       = lookup(forwarded_ip_config.value, "header_name")
                                position          = lookup(forwarded_ip_config.value, "position")
                              }
                            }`

For the top level ip_set_reference_statement the following dynamic statement is used.
`            dynamic "ip_set_forwarded_ip_config" {
              for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
              content {
                fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
                header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
                position          = lookup(ip_set_forwarded_ip_config.value, "position")
              }
            }`

Following the examples and testing I have found that ip_set_forwarded_ip_config is set on the top level dynamic statement as expected. but none of the nested statements work, the ip_set_forward_ip_config is ignored and not applied as expected.

As an example I had applied this following snippet
`      and_statement = {
        statements = [
          {
            not_statement = {
              ip_set_reference_statement = {
                arn = "arn:aws:wafv2:us-east-1:X:region/X"

                forwarded_ip_config = {
                  fallback_behavior = "NO_MATCH"
                  header_name       = "x--forwarded-for"
                  position          = "ANY"
                }
              }
            }
          },`
And I get the following error returned:
`│ Error: Reference to undeclared resource
│
│   on .terraform/modules/waf/main.tf line 5386, in resource "aws_wafv2_web_acl" "main":
│ 5386:                               position          = lookup(forwarded_ip_config.value, "position")
│
│ A managed resource "forwarded_ip_config" "value" has not been declared in
│ module.waf.
╵`

When I try this code 
`      and_statement = {
        statements = [
          {
            not_statement = {
              ip_set_reference_statement = {
                arn = "arn:aws:wafv2:us-east-1:X:region/X"

                ip_set_forwarded_ip_config = {
                  fallback_behavior = "NO_MATCH"
                  header_name       = "x--forwarded-for"
                  position          = "ANY"
                }
              }
            }
          },`
The plan shows no ip_set_forward_ip_config being applied, and just the arn is listed within the ip_set_reference_statement. I have tested my updates so that the nested dynamic statements match the top level statement and when I applied the last example statement above it works as expected and the ip_set_forwarded_ip_config is included in the plan.

Note: there is no change to the examples as the examples work with the proposed change but do not with the current setup.