### PR TITLE
Fix: enable_machine_learning option in aws_managed_rules_bot_control_rule_set

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -145,6 +145,7 @@ resource "aws_wafv2_web_acl" "main" {
                   for_each = length(lookup(managed_rule_group_configs.value, "aws_managed_rules_bot_control_rule_set", {})) == 0 ? [] : [lookup(managed_rule_group_configs.value, "aws_managed_rules_bot_control_rule_set", {})]
                   content {
                     inspection_level = lookup(aws_managed_rules_bot_control_rule_set.value, "inspection_level")
+                    enable_machine_learning = lookup(aws_managed_rules_bot_control_rule_set.value, "enable_machine_learning")
                   }
                 }
               }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.52.0"
+      version = ">= 5.60.0"
     }
   }
 }


### PR DESCRIPTION
### **Description of Changes**
This Pull Request adds support for the new _enable_machine_learning_ option in the _aws_managed_rules_bot_control_rule_set_ configuration block for the _aws_wafv2_web_acl_ resource. This option was introduced in AWS Provider version `5.59` and may lead to configuration drift if not explicitly managed in the module.

### **References**
- [Terraform AWS Provider Issue and Implementation](https://github.com/hashicorp/terraform-provider-aws/issues/37006)
- AWS Provider Version: 5.59

### Description
Fixes [#139](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/139)

- adding/fixing enable_machine_learning option for aws_managed_rules_bot_control_rule_set
