### PR TITLE
Feature / Add AWS Managed Rules ATP rule set

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -147,6 +147,26 @@ resource "aws_wafv2_web_acl" "main" {
                     inspection_level = lookup(aws_managed_rules_bot_control_rule_set.value, "inspection_level")
                   }
                 }
+
+                dynamic "aws_managed_rules_atp_rule_set" {
+                  for_each = length(lookup(managed_rule_group_configs.value, "aws_managed_rules_atp_rule_set", {})) == 0 ? [] : [lookup(managed_rule_group_configs.value, "aws_managed_rules_atp_rule_set", {})]
+                  content {
+                    login_path = aws_managed_rules_atp_rule_set.value.login_path
+                    
+                    request_inspection {
+                      password_field {
+                        identifier = aws_managed_rules_atp_rule_set.value.request_inspection.password_field
+                      }
+
+                      payload_type = try(aws_managed_rules_atp_rule_set.value.request_inspection.payload_type, "JSON") 
+
+                      username_field {
+                        identifier = aws_managed_rules_atp_rule_set.value.request_inspection.username_field
+                      }
+                    }
+                  }
+                }
+                
               }
             }
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.52.0"
+      version = ">= 5.0.0"
     }
   }
 }


### PR DESCRIPTION
# Description

This PR enables the configuration of the ATP rule set. This functionality allows us to protect from brute force attacks on a specified login, lost credentials and even, allows us to verify session and token issues.

## Related Terraform issues

Update from these two related issues:
- https://github.com/hashicorp/terraform-provider-aws/issues/23287
- https://github.com/hashicorp/terraform-provider-aws/issues/23290

(https://github.com/hashicorp/terraform-provider-aws/issues/23287#issuecomment-1372896160)
This functionality has been released in [v4.49.0 of the Terraform AWS Provider](https://github.com/hashicorp/terraform-provider-aws/blob/v4.49.0/CHANGELOG.md). 
