### PR TITLE
fix: changed loop and variable for ip_set rules inside statements

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -366,11 +366,11 @@ resource "aws_wafv2_web_acl" "main" {
                         content {
                           arn = lookup(ip_set_reference_statement.value, "arn")
                           dynamic "ip_set_forwarded_ip_config" {
-                            for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                            for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                             content {
-                              fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                              header_name       = lookup(forwarded_ip_config.value, "header_name")
-                              position          = lookup(forwarded_ip_config.value, "position")
+                              fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                              header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                              position          = lookup(ip_set_forwarded_ip_config.value, "position")
                             }
                           }
                         }
@@ -819,11 +819,11 @@ resource "aws_wafv2_web_acl" "main" {
                           content {
                             arn = lookup(ip_set_reference_statement.value, "arn")
                             dynamic "ip_set_forwarded_ip_config" {
-                              for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                              for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                               content {
-                                fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                                header_name       = lookup(forwarded_ip_config.value, "header_name")
-                                position          = lookup(forwarded_ip_config.value, "position")
+                                fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                                header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                                position          = lookup(ip_set_forwarded_ip_config.value, "position")
                               }
                             }
                           }
@@ -919,11 +919,11 @@ resource "aws_wafv2_web_acl" "main" {
                                 content {
                                   arn = lookup(ip_set_reference_statement.value, "arn")
                                   dynamic "ip_set_forwarded_ip_config" {
-                                    for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                                    for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                                     content {
-                                      fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                                      header_name       = lookup(forwarded_ip_config.value, "header_name")
-                                      position          = lookup(forwarded_ip_config.value, "position")
+                                      fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                                      header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                                      position          = lookup(ip_set_forwarded_ip_config.value, "position")
                                     }
                                   }
                                 }
@@ -1382,11 +1382,11 @@ resource "aws_wafv2_web_acl" "main" {
                                   content {
                                     arn = lookup(ip_set_reference_statement.value, "arn")
                                     dynamic "ip_set_forwarded_ip_config" {
-                                      for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                                      for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                                       content {
-                                        fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                                        header_name       = lookup(forwarded_ip_config.value, "header_name")
-                                        position          = lookup(forwarded_ip_config.value, "position")
+                                        fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                                        header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                                        position          = lookup(ip_set_forwarded_ip_config.value, "position")
                                       }
                                     }
                                   }
@@ -1677,11 +1677,11 @@ resource "aws_wafv2_web_acl" "main" {
                           content {
                             arn = lookup(ip_set_reference_statement.value, "arn")
                             dynamic "ip_set_forwarded_ip_config" {
-                              for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                              for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                               content {
-                                fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                                header_name       = lookup(forwarded_ip_config.value, "header_name")
-                                position          = lookup(forwarded_ip_config.value, "position")
+                                fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                                header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                                position          = lookup(ip_set_forwarded_ip_config.value, "position")
                               }
                             }
                           }
@@ -1951,11 +1951,11 @@ resource "aws_wafv2_web_acl" "main" {
                                 content {
                                   arn = lookup(ip_set_reference_statement.value, "arn")
                                   dynamic "ip_set_forwarded_ip_config" {
-                                    for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                                    for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                                     content {
-                                      fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                                      header_name       = lookup(forwarded_ip_config.value, "header_name")
-                                      position          = lookup(forwarded_ip_config.value, "position")
+                                      fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                                      header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                                      position          = lookup(ip_set_forwarded_ip_config.value, "position")
                                     }
                                   }
                                 }
@@ -2821,11 +2821,11 @@ resource "aws_wafv2_web_acl" "main" {
                   content {
                     arn = lookup(ip_set_reference_statement.value, "arn")
                     dynamic "ip_set_forwarded_ip_config" {
-                      for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                      for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                       content {
-                        fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                        header_name       = lookup(forwarded_ip_config.value, "header_name")
-                        position          = lookup(forwarded_ip_config.value, "position")
+                        fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                        header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                        position          = lookup(ip_set_forwarded_ip_config.value, "position")
                       }
                     }
                   }
@@ -2842,11 +2842,11 @@ resource "aws_wafv2_web_acl" "main" {
                         content {
                           arn = lookup(ip_set_reference_statement.value, "arn")
                           dynamic "ip_set_forwarded_ip_config" {
-                            for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                            for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                             content {
-                              fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                              header_name       = lookup(forwarded_ip_config.value, "header_name")
-                              position          = lookup(forwarded_ip_config.value, "position")
+                              fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                              header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                              position          = lookup(ip_set_forwarded_ip_config.value, "position")
                             }
                           }
                         }
@@ -3226,11 +3226,11 @@ resource "aws_wafv2_web_acl" "main" {
                           content {
                             arn = lookup(ip_set_reference_statement.value, "arn")
                             dynamic "ip_set_forwarded_ip_config" {
-                              for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                              for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                               content {
-                                fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                                header_name       = lookup(forwarded_ip_config.value, "header_name")
-                                position          = lookup(forwarded_ip_config.value, "position")
+                                fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                                header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                                position          = lookup(ip_set_forwarded_ip_config.value, "position")
                               }
                             }
                           }
@@ -3256,11 +3256,11 @@ resource "aws_wafv2_web_acl" "main" {
                                 content {
                                   arn = lookup(ip_set_reference_statement.value, "arn")
                                   dynamic "ip_set_forwarded_ip_config" {
-                                    for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                                    for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                                     content {
-                                      fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                                      header_name       = lookup(forwarded_ip_config.value, "header_name")
-                                      position          = lookup(forwarded_ip_config.value, "position")
+                                      fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                                      header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                                      position          = lookup(ip_set_forwarded_ip_config.value, "position")
                                     }
                                   }
                                 }
@@ -3640,11 +3640,11 @@ resource "aws_wafv2_web_acl" "main" {
                                   content {
                                     arn = lookup(ip_set_reference_statement.value, "arn")
                                     dynamic "ip_set_forwarded_ip_config" {
-                                      for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                                      for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                                       content {
-                                        fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                                        header_name       = lookup(forwarded_ip_config.value, "header_name")
-                                        position          = lookup(forwarded_ip_config.value, "position")
+                                        fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                                        header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                                        position          = lookup(ip_set_forwarded_ip_config.value, "position")
                                       }
                                     }
                                   }
@@ -4090,11 +4090,11 @@ resource "aws_wafv2_web_acl" "main" {
                           content {
                             arn = lookup(ip_set_reference_statement.value, "arn")
                             dynamic "ip_set_forwarded_ip_config" {
-                              for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                              for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                               content {
-                                fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                                header_name       = lookup(forwarded_ip_config.value, "header_name")
-                                position          = lookup(forwarded_ip_config.value, "position")
+                                fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                                header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                                position          = lookup(ip_set_forwarded_ip_config.value, "position")
                               }
                             }
                           }
@@ -4650,11 +4650,11 @@ resource "aws_wafv2_web_acl" "main" {
                 content {
                   arn = lookup(ip_set_reference_statement.value, "arn")
                   dynamic "ip_set_forwarded_ip_config" {
-                    for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                    for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                     content {
-                      fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                      header_name       = lookup(forwarded_ip_config.value, "header_name")
-                      position          = lookup(forwarded_ip_config.value, "position")
+                      fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                      header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                      position          = lookup(ip_set_forwarded_ip_config.value, "position")
                     }
                   }
                 }
@@ -4940,11 +4940,11 @@ resource "aws_wafv2_web_acl" "main" {
                   content {
                     arn = lookup(ip_set_reference_statement.value, "arn")
                     dynamic "ip_set_forwarded_ip_config" {
-                      for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                      for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                       content {
-                        fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                        header_name       = lookup(forwarded_ip_config.value, "header_name")
-                        position          = lookup(forwarded_ip_config.value, "position")
+                        fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                        header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                        position          = lookup(ip_set_forwarded_ip_config.value, "position")
                       }
                     }
                   }
@@ -5379,11 +5379,11 @@ resource "aws_wafv2_web_acl" "main" {
                         content {
                           arn = lookup(ip_set_reference_statement.value, "arn")
                           dynamic "ip_set_forwarded_ip_config" {
-                            for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                            for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                             content {
-                              fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                              header_name       = lookup(forwarded_ip_config.value, "header_name")
-                              position          = lookup(forwarded_ip_config.value, "position")
+                              fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                              header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                              position          = lookup(ip_set_forwarded_ip_config.value, "position")
                             }
                           }
                         }
@@ -5669,11 +5669,11 @@ resource "aws_wafv2_web_acl" "main" {
                           content {
                             arn = lookup(ip_set_reference_statement.value, "arn")
                             dynamic "ip_set_forwarded_ip_config" {
-                              for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                              for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                               content {
-                                fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                                header_name       = lookup(forwarded_ip_config.value, "header_name")
-                                position          = lookup(forwarded_ip_config.value, "position")
+                                fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                                header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                                position          = lookup(ip_set_forwarded_ip_config.value, "position")
                               }
                             }
                           }
@@ -5952,11 +5952,11 @@ resource "aws_wafv2_web_acl" "main" {
                                 content {
                                   arn = lookup(ip_set_reference_statement.value, "arn")
                                   dynamic "ip_set_forwarded_ip_config" {
-                                    for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                                    for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                                     content {
-                                      fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                                      header_name       = lookup(forwarded_ip_config.value, "header_name")
-                                      position          = lookup(forwarded_ip_config.value, "position")
+                                      fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                                      header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                                      position          = lookup(ip_set_forwarded_ip_config.value, "position")
                                     }
                                   }
                                 }
@@ -6407,11 +6407,11 @@ resource "aws_wafv2_web_acl" "main" {
                   content {
                     arn = lookup(ip_set_reference_statement.value, "arn")
                     dynamic "ip_set_forwarded_ip_config" {
-                      for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                      for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                       content {
-                        fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                        header_name       = lookup(forwarded_ip_config.value, "header_name")
-                        position          = lookup(forwarded_ip_config.value, "position")
+                        fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                        header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                        position          = lookup(ip_set_forwarded_ip_config.value, "position")
                       }
                     }
                   }
@@ -6690,11 +6690,11 @@ resource "aws_wafv2_web_acl" "main" {
                         content {
                           arn = lookup(ip_set_reference_statement.value, "arn")
                           dynamic "ip_set_forwarded_ip_config" {
-                            for_each = length(lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "forwarded_ip_config", {})]
+                            for_each = length(lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})) == 0 ? [] : [lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", {})]
                             content {
-                              fallback_behavior = lookup(forwarded_ip_config.value, "fallback_behavior")
-                              header_name       = lookup(forwarded_ip_config.value, "header_name")
-                              position          = lookup(forwarded_ip_config.value, "position")
+                              fallback_behavior = lookup(ip_set_forwarded_ip_config.value, "fallback_behavior")
+                              header_name       = lookup(ip_set_forwarded_ip_config.value, "header_name")
+                              position          = lookup(ip_set_forwarded_ip_config.value, "position")
                             }
                           }
                         }


### PR DESCRIPTION
Fixed bug in ip_set configurations inside statement definitions to use the right inner variable.
