### PR TITLE
Add support for ATP and AntiDDoS rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,13 +430,13 @@ Module managed by:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.52.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.52.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.2.0 |
 
 ## Modules
 

--- a/examples/core/versions.tf
+++ b/examples/core/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5"
+      version = "~> 6.2.0"
     }
   }
 }

--- a/examples/wafv2-and-or-rules/versions.tf
+++ b/examples/wafv2-and-or-rules/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5"
+      version = "~> 6.2.0"
     }
   }
 }

--- a/examples/wafv2-bytematch-rules/versions.tf
+++ b/examples/wafv2-bytematch-rules/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5"
+      version = "~> 6.2.0"
     }
   }
 }

--- a/examples/wafv2-custom-json-response-managed-rule-group/versions.tf
+++ b/examples/wafv2-custom-json-response-managed-rule-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5"
+      version = "~> 6.2.0"
     }
   }
 }

--- a/examples/wafv2-custom-response-code/versions.tf
+++ b/examples/wafv2-custom-response-code/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5"
+      version = "~> 6.2.0"
     }
   }
 }

--- a/examples/wafv2-custom-response/versions.tf
+++ b/examples/wafv2-custom-response/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5"
+      version = "~> 6.2.0"
     }
   }
 }

--- a/examples/wafv2-geo-rules/versions.tf
+++ b/examples/wafv2-geo-rules/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5"
+      version = "~> 6.2.0"
     }
   }
 }

--- a/examples/wafv2-ip-rules/versions.tf
+++ b/examples/wafv2-ip-rules/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5"
+      version = "~> 6.2.0"
     }
   }
 }

--- a/examples/wafv2-labelmatch-rules/versions.tf
+++ b/examples/wafv2-labelmatch-rules/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5"
+      version = "~> 6.2.0"
     }
   }
 }

--- a/examples/wafv2-logging-configuration/versions.tf
+++ b/examples/wafv2-logging-configuration/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5"
+      version = "~> 6.2.0"
     }
   }
 }

--- a/examples/wafv2-regex-pattern-rules/versions.tf
+++ b/examples/wafv2-regex-pattern-rules/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5"
+      version = "~> 6.2.0"
     }
   }
 }

--- a/examples/wafv2-regexmatch-rules/versions.tf
+++ b/examples/wafv2-regexmatch-rules/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5"
+      version = "~> 6.2.0"
     }
   }
 }

--- a/examples/wafv2-sizeconstraint-rules/versions.tf
+++ b/examples/wafv2-sizeconstraint-rules/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5"
+      version = "~> 6.2.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -196,11 +196,11 @@ resource "aws_wafv2_web_acl" "main" {
                             sensitivity     = try(challenge.value.sensitivity, "HIGH")
                             usage_of_action = try(challenge.value.usage_of_action, null)
 
-                            dynamic "exempt_uri_regular_expressions" {
-                              for_each = try(challenge.value.exempt_uri_regular_expressions, [])
+                            dynamic "exempt_uri_regular_expression" {
+                              for_each = try(challenge.value.exempt_uri_regular_expression, [])
 
                               content {
-                                regex_string = try(exempt_uri_regular_expressions.value.regex_string, null)
+                                regex_string = try(exempt_uri_regular_expression.value.regex_string, null)
                               }
                             }
                           }

--- a/main.tf
+++ b/main.tf
@@ -147,6 +147,68 @@ resource "aws_wafv2_web_acl" "main" {
                     inspection_level = lookup(aws_managed_rules_bot_control_rule_set.value, "inspection_level")
                   }
                 }
+
+                dynamic "aws_managed_rules_atp_rule_set" {
+                  for_each = try([managed_rule_group_configs.value.aws_managed_rules_atp_rule_set], [])
+                  content {
+                    login_path           = try(aws_managed_rules_atp_rule_set.value.login_path, null)
+                    enable_regex_in_path = try(aws_managed_rules_atp_rule_set.value.enable_regex_in_path, null)
+
+                    dynamic "request_inspection" {
+                      for_each = try([aws_managed_rules_atp_rule_set.value.request_inspection], [])
+
+                      content {
+                        payload_type = try(request_inspection.value.payload_type, "JSON")
+
+                        dynamic "password_field" {
+                          for_each = try([request_inspection.value.password_field], [])
+
+                          content {
+                            identifier = try(password_field.value.identifier, null)
+                          }
+                        }
+
+                        dynamic "username_field" {
+                          for_each = try([request_inspection.value.username_field], [])
+
+                          content {
+                            identifier = try(username_field.value.identifier, null)
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+
+                dynamic "aws_managed_rules_anti_ddos_rule_set" {
+                  for_each = try([managed_rule_group_configs.value.aws_managed_rules_anti_ddos_rule_set], [])
+                  content {
+                    sensitivity_to_block = try(aws_managed_rules_anti_ddos_rule_set.value.sensitivity_to_block, "LOW")
+
+                    dynamic "client_side_action_config" {
+                      for_each = try([aws_managed_rules_anti_ddos_rule_set.value.client_side_action_config], [])
+
+                      content {
+                        dynamic "challenge" {
+                          for_each = try([client_side_action_config.value.challenge], [])
+
+                          content {
+                            sensitivity     = try(challenge.value.sensitivity, "HIGH")
+                            usage_of_action = try(challenge.value.usage_of_action, null)
+
+                            dynamic "exempt_uri_regular_expressions" {
+                              for_each = try(challenge.value.exempt_uri_regular_expressions, [])
+
+                              content {
+                                regex_string = try(exempt_uri_regular_expressions.value.regex_string, null)
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
               }
             }
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.52.0"
+      version = ">= 6.2.0"
     }
   }
 }


### PR DESCRIPTION
# Description

1. Support ATP and AntiDDoS rules 
2. AWS Provider upgrade as the support for AntiDDoS rule was added in 6.2.0

https://github.com/hashicorp/terraform-provider-aws/releases/tag/v6.2.0
https://github.com/hashicorp/terraform-provider-aws/pull/43149
https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-anti-ddos.html

https://github.com/hashicorp/terraform-provider-aws/issues/23287
https://github.com/hashicorp/terraform-provider-aws/issues/23290
https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-atp.html